### PR TITLE
Adding authentication configuration to the remoteDataObject when creating new jobs

### DIFF
--- a/app/components/authentication-configuration.hbs
+++ b/app/components/authentication-configuration.hbs
@@ -1,0 +1,91 @@
+<div class='au-u-margin-bottom'>
+  <AuLabel for='task-authentication-configuration'>
+    Authentication Configuration
+    <AuPill>Optional</AuPill>
+  </AuLabel>
+  <PowerSelect
+    @allowClear={{true}}
+    @options={{@options}}
+    @selected={{@selected}}
+    @onChange={{@onChange}}
+    as |option|
+  >
+    {{option.label}}
+  </PowerSelect>
+  <AuHelpText>
+    When you provide an
+    <strong>URL</strong>
+    that is public you wont need to select an authentication configuration.
+    <br />
+  </AuHelpText>
+</div>
+{{#if (eq @selected.label 'Basic')}}
+  <div class='au-u-margin-bottom'>
+    <AuLabel for='task-authentication-configuration-username'>
+      Username
+    </AuLabel>
+    <AuInput
+      id='task-authentication-configuration-username'
+      @width='block'
+      @value={{@credentials.username}}
+      {{on 'change' (fn this.handleCredentialsChange 'username' @credentials.username)}}
+    />
+  </div>
+  <div>
+    <AuLabel for='task-authentication-configuration-password'>
+      Password
+    </AuLabel>
+    <AuInput
+      id='task-authentication-configuration-password'
+      @width='block'
+      @value={{@credentials.password}}
+      {{on 'change' (fn this.handleCredentialsChange 'password' @credentials.password)}}
+    />
+  </div>
+{{/if}}
+{{#if (eq @selected.label 'Oauth2')}}
+  <div class='au-u-margin-bottom'>
+    <AuLabel for='task-authentication-configuration-flow'>
+      Flow
+    </AuLabel>
+    <AuInput
+      id='task-authentication-configuration-flow'
+      @width='block'
+      @value={{@securityScheme.flow}}
+      {{on 'change' (fn this.handleSecuritySchemeChange 'flow' @securityScheme.flow)}}
+    />
+  </div>
+  <div class='au-u-margin-bottom'>
+    <AuLabel for='task-authentication-configuration-token'>
+      Token URI
+    </AuLabel>
+    <AuInput
+      id='task-authentication-configuration-token'
+      @width='block'
+      @value={{@securityScheme.token}}
+      {{on 'change' (fn this.handleSecuritySchemeChange 'token' @securityScheme.token)}}
+    />
+  </div>
+  <div class='au-u-margin-bottom'>
+    <AuLabel for='task-authentication-configuration-clientId'>
+      ClientId
+    </AuLabel>
+    <AuInput
+      id='task-authentication-configuration-clientId'
+      @width='block'
+      @value={{@credentials.clientId}}
+      {{on 'change' (fn this.handleCredentialsChange 'clientId' @credentials.clientId)}}
+    />
+  </div>
+  <div>
+    <AuLabel for='task-authentication-configuration-clientSecret'>
+      Client Secret
+    </AuLabel>
+    <AuInput
+      id='task-authentication-configuration-clientSecret'
+      @width='block'
+      @value={{@credentials.clientSecret}}
+      {{on 'change' (fn this.handleCredentialsChange 'clientSecret' @credentials.clientSecret)}}
+    />
+  </div>
+{{/if}}

--- a/app/components/authentication-configuration.js
+++ b/app/components/authentication-configuration.js
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class AuthenticationConfiguration extends Component {
+  @action
+  handleCredentialsChange(attributeName, value) {
+    this.args.onCredentialsChange(attributeName, value);
+  }
+
+  @action
+  handleSecuritySchemeChange(attributeName, value) {
+    this.args.onSecuritySchemeChange(attributeName, value);
+  }
+}

--- a/app/controllers/scheduled-jobs/new.js
+++ b/app/controllers/scheduled-jobs/new.js
@@ -9,7 +9,10 @@ import {
   JOB_CREATOR_SELF_SERVICE,
   JOB_OP_TYPE_HARVEST_WORSHIP,
   JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT,
+  BASIC_AUTH,
+  OAUTH2,
 } from '../../utils/constants';
+import createAuthenticationConfiguration from '../../utils/create-authentication-configuration';
 
 export default class ScheduledJobsNewController extends Controller {
   jobHarvest = JOB_OP_TYPE_HARVEST;
@@ -34,6 +37,8 @@ export default class ScheduledJobsNewController extends Controller {
 
   creator = JOB_CREATOR_SELF_SERVICE;
 
+  securitySchemesOptions = [BASIC_AUTH, OAUTH2];
+
   @tracked title;
   @tracked url;
   @tracked graphName;
@@ -42,6 +47,9 @@ export default class ScheduledJobsNewController extends Controller {
   @tracked errorMessage;
   @tracked selectedJobOperation;
   @tracked cronPattern = '*/5 * * * *';
+  @tracked selectedSecurityScheme;
+  @tracked securityScheme = {};
+  @tracked credentials = {};
 
   get cronDescription() {
     const isValidCronExpression = isValidCron(this.cronPattern);
@@ -62,6 +70,20 @@ export default class ScheduledJobsNewController extends Controller {
   get currentTime() {
     const timestamp = new Date();
     return timestamp;
+  }
+
+  @action
+  updateCredentials(attributeName, credentials) {
+    this.credentials[attributeName] = credentials;
+  }
+  @action
+  updateSecurityScheme(attributeName, securityScheme) {
+    this.securityScheme[attributeName] = securityScheme;
+  }
+
+  @action
+  setSecurityScheme(selected) {
+    this.selectedSecurityScheme = selected;
   }
 
   @action
@@ -92,6 +114,14 @@ export default class ScheduledJobsNewController extends Controller {
       created: this.currentTime,
       modified: this.currentTime,
       creator: this.creator,
+      authenticationConfiguration: this.selectedSecurityScheme
+        ? await createAuthenticationConfiguration(
+            this.selectedSecurityScheme,
+            this.securityScheme,
+            this.credentials,
+            this.store
+          )
+        : null, // authenticationConfiguration is optional
     });
 
     const collection = this.store.createRecord('harvesting-collection', {

--- a/app/models/authentication-configuration.js
+++ b/app/models/authentication-configuration.js
@@ -1,0 +1,6 @@
+import Model, { belongsTo } from '@ember-data/model';
+
+export default class AuthenticationConfiguration extends Model {
+  @belongsTo('credential') credential;
+  @belongsTo('security-scheme') securityScheme;
+}

--- a/app/models/authentication-configuration.js
+++ b/app/models/authentication-configuration.js
@@ -1,6 +1,7 @@
-import Model, { belongsTo } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class AuthenticationConfiguration extends Model {
+  @attr uri;
   @belongsTo('credential') credential;
   @belongsTo('security-scheme') securityScheme;
 }

--- a/app/models/basic-authentication-credential.js
+++ b/app/models/basic-authentication-credential.js
@@ -1,0 +1,7 @@
+import { attr } from '@ember-data/model';
+import Credential from './credential';
+
+export default class BasicAuthenticationCredential extends Credential {
+  @attr('string') username;
+  @attr('string') password;
+}

--- a/app/models/basic-authentication-credential.js
+++ b/app/models/basic-authentication-credential.js
@@ -2,6 +2,7 @@ import { attr } from '@ember-data/model';
 import Credential from './credential';
 
 export default class BasicAuthenticationCredential extends Credential {
+  @attr uri;
   @attr('string') username;
   @attr('string') password;
 }

--- a/app/models/basic-security-scheme.js
+++ b/app/models/basic-security-scheme.js
@@ -1,0 +1,3 @@
+import SecurityScheme from './security-scheme';
+
+export default class BasicSecurityScheme extends SecurityScheme {}

--- a/app/models/credential.js
+++ b/app/models/credential.js
@@ -1,0 +1,3 @@
+import Model from '@ember-data/model';
+// Abstract superclass
+export default class Credential extends Model {}

--- a/app/models/oauth2-credential.js
+++ b/app/models/oauth2-credential.js
@@ -1,0 +1,7 @@
+import { attr } from '@ember-data/model';
+import Credential from './credential';
+
+export default class Oauth2Credential extends Credential {
+  @attr('string') clientId;
+  @attr('string') clientSecret;
+}

--- a/app/models/oauth2-credential.js
+++ b/app/models/oauth2-credential.js
@@ -2,6 +2,7 @@ import { attr } from '@ember-data/model';
 import Credential from './credential';
 
 export default class Oauth2Credential extends Credential {
+  @attr uri;
   @attr('string') clientId;
   @attr('string') clientSecret;
 }

--- a/app/models/oauth2-security-scheme.js
+++ b/app/models/oauth2-security-scheme.js
@@ -2,6 +2,7 @@ import { attr } from '@ember-data/model';
 import SecurityScheme from './security-scheme';
 
 export default class Oauth2SecurityScheme extends SecurityScheme {
+  @attr uri;
   @attr('string') token;
   @attr('string') flow;
 }

--- a/app/models/oauth2-security-scheme.js
+++ b/app/models/oauth2-security-scheme.js
@@ -1,0 +1,7 @@
+import { attr } from '@ember-data/model';
+import SecurityScheme from './security-scheme';
+
+export default class Oauth2SecurityScheme extends SecurityScheme {
+  @attr('string') token;
+  @attr('string') flow;
+}

--- a/app/models/remote-data-object.js
+++ b/app/models/remote-data-object.js
@@ -9,6 +9,8 @@ export default class RemoteDataObjectModel extends Model {
   @attr('string') requestHeader;
   @attr('string') creator;
   @belongsTo('file') file;
+  @belongsTo('harvesting-collection') harvestingCollection;
+  @belongsTo('authentication-configuration') authenticationConfiguration;
 
   //TODO: move this later to a propery modeled skos:Conceptscheme
   statusesMap = {

--- a/app/models/security-scheme.js
+++ b/app/models/security-scheme.js
@@ -1,0 +1,3 @@
+import Model from '@ember-data/model';
+// Abstract superclass
+export default class SecurityScheme extends Model {}

--- a/app/routes/jobs/new.js
+++ b/app/routes/jobs/new.js
@@ -9,5 +9,8 @@ export default class JobsNewRoute extends Route {
     controller.set('url', null);
     controller.set('comment', null);
     controller.set('graphName', null);
+    controller.set('selectedSecurityScheme', null);
+    controller.set('credentials', {});
+    controller.set('securityScheme', {});
   }
 }

--- a/app/routes/scheduled-jobs/new.js
+++ b/app/routes/scheduled-jobs/new.js
@@ -10,5 +10,8 @@ export default class ScheduledJobsNewRoute extends Route {
     controller.set('title', '');
     controller.set('comment', '');
     controller.set('cronPattern', '*/5 * * * *');
+    controller.set('selectedSecurityScheme', null);
+    controller.set('credentials', {});
+    controller.set('securityScheme', {});
   }
 }

--- a/app/templates/jobs/new.hbs
+++ b/app/templates/jobs/new.hbs
@@ -56,12 +56,21 @@
           </AuLabel>
           <AuTextarea id="task-comment" @width="block" @value={{this.comment}} placeholder="Some details, if required!" {{! template-lint-disable no-duplicate-id }} />
         </div>
-        <div>
+        <div class='au-u-margin-bottom'>
           <AuLabel for="task-creator">
             Creator
           </AuLabel>
           <AuInput id="task-creator" @width="block" @value={{this.creator}} disabled={{true}} {{! template-lint-disable no-duplicate-id }} />
         </div>
+        <AuthenticationConfiguration
+          @options={{this.securitySchemesOptions}}
+          @selected={{this.selectedSecurityScheme}}
+          @onChange={{this.setSecurityScheme}}
+          @credentials={{this.credentials}}
+          @securityScheme={{this.securityScheme}}
+          @onCredentialsChange={{this.updateCredentials}}
+          @onSecuritySchemeChange={{this.updateSecurityScheme}}
+        />
         <AuButton class="au-u-margin-top-large" {{on 'click' this.scheduleHarvestJob}}>Schedule</AuButton>
         {{/if}}
 

--- a/app/templates/jobs/new.hbs
+++ b/app/templates/jobs/new.hbs
@@ -34,12 +34,21 @@
           </AuLabel>
           <AuTextarea id="task-comment" @width="block" @value={{this.comment}} placeholder="Some details, if required!" />
         </div>
-        <div>
+        <div class="au-u-margin-bottom">
           <AuLabel for="task-creator">
             Creator
           </AuLabel>
           <AuInput id="task-creator" @width="block" @value={{this.creator}} disabled={{true}} />
         </div>
+        <AuthenticationConfiguration
+          @options={{this.securitySchemesOptions}}
+          @selected={{this.selectedSecurityScheme}}
+          @onChange={{this.setSecurityScheme}}
+          @credentials={{this.credentials}}
+          @securityScheme={{this.securityScheme}}
+          @onCredentialsChange={{this.updateCredentials}}
+          @onSecuritySchemeChange={{this.updateSecurityScheme}}
+        />
         <AuButton class="au-u-margin-top-large" {{on 'click' this.scheduleHarvestJob}}>Schedule</AuButton>
         {{/if}}
 
@@ -110,12 +119,21 @@
           </AuLabel>
           <AuTextarea id="task-hw-comment" @width="block" @value={{this.comment}} placeholder="Some details, if required!" />
         </div>
-        <div>
+        <div class="au-u-margin-bottom">
           <AuLabel for="task-hw-creator">
             Creator
           </AuLabel>
           <AuInput id="task-hw-creator" @width="block" @value={{this.creator}} disabled={{true}} />
         </div>
+        <AuthenticationConfiguration
+          @options={{this.securitySchemesOptions}}
+          @selected={{this.selectedSecurityScheme}}
+          @onChange={{this.setSecurityScheme}}
+          @credentials={{this.credentials}}
+          @securityScheme={{this.securityScheme}}
+          @onCredentialsChange={{this.updateCredentials}}
+          @onSecuritySchemeChange={{this.updateSecurityScheme}}
+        />
         <AuButton class="au-u-margin-top-large" {{on 'click' this.scheduleHarvestJob}}>Schedule</AuButton>
         {{/if}}
       </div>

--- a/app/templates/scheduled-jobs/new.hbs
+++ b/app/templates/scheduled-jobs/new.hbs
@@ -63,12 +63,21 @@
             Try to think about spreading the load on the server, by spreading the jobs in time.
           </AuHelpText>
         </div>
-        <div>
+        <div class="au-u-margin-bottom">
           <AuLabel for="task-creator">
             Creator
           </AuLabel>
           <AuInput id="task-creator" @width="block" @value={{this.creator}} disabled={{true}} />
         </div>
+        <AuthenticationConfiguration
+          @options={{this.securitySchemesOptions}}
+          @selected={{this.selectedSecurityScheme}}
+          @onChange={{this.setSecurityScheme}}
+          @credentials={{this.credentials}}
+          @securityScheme={{this.securityScheme}}
+          @onCredentialsChange={{this.updateCredentials}}
+          @onSecuritySchemeChange={{this.updateSecurityScheme}}
+        />
         <AuButton class="au-u-margin-top-large" @disabled={{not this.isValidCron}} {{on 'click' this.createScheduledJob}}>Schedule</AuButton>
         {{/if}}
       </div>

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -21,6 +21,15 @@ export const JOB_OP_TYPE_HEALING_WORSHIP =
 export const JOB_OP_TYPE_DUMPED_WORSHIP =
   'http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/worship';
 
+// Auth Type
+export const BASIC_AUTH = {
+  label: 'Basic',
+  uri: 'https://www.w3.org/2019/wot/security#BasicSecurityScheme',
+};
+export const OAUTH2 = {
+  label: 'Oauth2',
+  uri: 'https://www.w3.org/2019/wot/security#OAuth2SecurityScheme',
+};
 
 export const JOB_OP_TYPES = new Map();
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVEST, 'Harvest URL');

--- a/app/utils/create-authentication-configuration.js
+++ b/app/utils/create-authentication-configuration.js
@@ -1,0 +1,57 @@
+/**
+ * Creates the correct `authentication-configuration` for `basic` and `oauth2` authentication methods.
+ * @param {Object} securitySchemeType
+ * @param {Object} securitySchemeConfig
+ * @param {Object} credentials
+ * @param {Object} store
+ * @returns authConfig
+ */
+export default async function createAuthenticationConfiguration(
+  securitySchemeType,
+  securitySchemeConfig,
+  credentials,
+  store
+) {
+  const getSecuritySchemeModel = (securitySchemeType) => {
+    switch (securitySchemeType.label) {
+      case 'Basic':
+        return 'basic-security-scheme';
+      case 'Oauth2':
+        return 'oauth2-security-scheme';
+      default:
+        return 'security-scheme';
+    }
+  };
+
+  const getCredentialModel = (securitySchemeType) => {
+    switch (securitySchemeType.label) {
+      case 'Basic':
+        return 'basic-authentication-credential';
+      case 'Oauth2':
+        return 'oauth2-credential';
+      default:
+        return 'credential';
+    }
+  };
+
+  let securityScheme = await store.createRecord(
+    getSecuritySchemeModel(securitySchemeType),
+    securitySchemeType.label === 'Oauth2' ? securitySchemeConfig : ''
+  );
+
+  let credential = await store.createRecord(
+    getCredentialModel(securitySchemeType),
+    credentials
+  );
+
+  let authConfig = await store.createRecord('authentication-configuration', {
+    securityScheme,
+    credential,
+  });
+
+  await securityScheme.save();
+  await credential.save();
+  await authConfig.save();
+
+  return authConfig;
+}


### PR DESCRIPTION
DL-4848

This adds an extra field to choose from basic or oauth2 authentication method for the Harvest URL job. Note that this field is optional and will only be needed for 'private' urls

When the method is picked, it will show the required credentials and security scheme fields to fill in order to run the job and then harvest the 'private' data.

Related to https://github.com/lblod/app-lblod-harvester/pull/25

