### PR TITLE
Better button state on scheduling

### DIFF
--- a/app/controllers/jobs/new.js
+++ b/app/controllers/jobs/new.js
@@ -74,7 +74,6 @@ export default class JobsNewController extends Controller {
   @action
   setJobOperation(selected) {
     this.selectedJobOperation = selected;
-    this.scheduling = false;
   }
 
   @action

--- a/app/routes/jobs/new.js
+++ b/app/routes/jobs/new.js
@@ -4,8 +4,7 @@ export default class JobsNewRoute extends Route {
   setupController(controller /*, model */) {
     super.setupController(...arguments);
     controller.set('selectedJobOperation', null);
-    controller.set('success', false);
-    controller.set('error', false);
+    controller.set('scheduling', false);
     controller.set('url', null);
     controller.set('comment', null);
     controller.set('graphName', null);

--- a/app/routes/scheduled-jobs/new.js
+++ b/app/routes/scheduled-jobs/new.js
@@ -4,8 +4,7 @@ export default class ScheduledJobsNewRoute extends Route {
   setupController(controller /*, model */) {
     super.setupController(...arguments);
     controller.set('selectedJobOperation', null);
-    controller.set('success', false);
-    controller.set('error', false);
+    controller.set('scheduling', false);
     controller.set('url', null);
     controller.set('title', '');
     controller.set('comment', '');

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,5 @@
 {{page-title "Harvesting self service"}}
+<AuToaster @position="top"/>
 <AuApp>
   <AuMainHeader @appTitle="Job Dashboard" @brandLink="https://www.vlaanderen.be/nl" @homeRoute="index">
     {{#if this.authenticationEnabled}}

--- a/app/templates/jobs/new.hbs
+++ b/app/templates/jobs/new.hbs
@@ -51,7 +51,14 @@
             @onSecuritySchemeChange={{this.updateSecurityScheme}}
           />
         {{/if}}
-        <AuButton class="au-u-margin-top-large" {{on 'click' this.scheduleHarvestJob}}>Schedule</AuButton>
+        <AuButton
+          class="au-u-margin-top-large"
+          {{on 'click' this.scheduleHarvestJob}}
+          @disabled={{this.scheduling}}
+          @loading={{this.scheduling}}
+          @loadingMessage="Scheduling">
+          Schedule
+        </AuButton>
         {{/if}}
 
         {{#if (eq this.selectedJobOperation.uri this.jobHarvest)}}
@@ -84,7 +91,14 @@
             @onSecuritySchemeChange={{this.updateSecurityScheme}}
           />
         {{/if}}
-        <AuButton class="au-u-margin-top-large" {{on 'click' this.scheduleHarvestJob}}>Schedule</AuButton>
+        <AuButton
+          class="au-u-margin-top-large"
+          {{on 'click' this.scheduleHarvestJob}}
+          @disabled={{this.scheduling}}
+          @loading={{this.scheduling}}
+          @loadingMessage="Scheduling">
+          Schedule
+        </AuButton>
         {{/if}}
 
         {{#if (eq this.selectedJobOperation.uri this.jobImport )}}
@@ -106,59 +120,57 @@
           </AuLabel>
           <AuInput id="task-creator" @width="block" @value={{this.creator}} disabled={{true}} {{! template-lint-disable no-duplicate-id }} />
         </div>
-        <AuButton class="au-u-margin-top-large" {{on 'click' this.scheduleImportJob}}>Schedule</AuButton>
+        <AuButton
+          class="au-u-margin-top-large"
+          {{on 'click' this.scheduleImportJob}}
+          @disabled={{this.scheduling}}
+          @loading={{this.scheduling}}
+          @loadingMessage="Scheduling">
+          Schedule
+        </AuButton>
         {{/if}}
 
         {{#if (or (eq this.selectedJobOperation.uri this.jobHarvestWorshipAndImport)
                   (eq this.selectedJobOperation.uri this.jobHarvestWorship))}}
-        <div class="au-u-margin-bottom">
-          <AuLabel for="task-hw-url">
-            URL
-          </AuLabel>
-          <AuInput id="task-hw-url" @width="block" @value={{this.url}} />
-        </div>
-        <div class="au-u-margin-bottom">
-          <AuLabel for="task-hw-comment">
-            Comments
-          </AuLabel>
-          <AuTextarea id="task-hw-comment" @width="block" @value={{this.comment}} placeholder="Some details, if required!" />
-        </div>
-        <div class="au-u-margin-bottom">
-          <AuLabel for="task-hw-creator">
-            Creator
-          </AuLabel>
-          <AuInput id="task-hw-creator" @width="block" @value={{this.creator}} disabled={{true}} />
-        </div>
-        {{#if this.authenticationEnabled}}
-          <AuthenticationConfiguration
-            @options={{this.securitySchemesOptions}}
-            @selected={{this.selectedSecurityScheme}}
-            @onChange={{this.setSecurityScheme}}
-            @credentials={{this.credentials}}
-            @securityScheme={{this.securityScheme}}
-            @onCredentialsChange={{this.updateCredentials}}
-            @onSecuritySchemeChange={{this.updateSecurityScheme}}
-          />
-        {{/if}}
-        <AuButton class="au-u-margin-top-large" {{on 'click' this.scheduleHarvestJob}}>Schedule</AuButton>
+          <div class="au-u-margin-bottom">
+            <AuLabel for="task-hw-url">
+              URL
+            </AuLabel>
+            <AuInput id="task-hw-url" @width="block" @value={{this.url}} />
+          </div>
+          <div class="au-u-margin-bottom">
+            <AuLabel for="task-hw-comment">
+              Comments
+            </AuLabel>
+            <AuTextarea id="task-hw-comment" @width="block" @value={{this.comment}} placeholder="Some details, if required!" />
+          </div>
+          <div class="au-u-margin-bottom">
+            <AuLabel for="task-hw-creator">
+              Creator
+            </AuLabel>
+            <AuInput id="task-hw-creator" @width="block" @value={{this.creator}} disabled={{true}} />
+          </div>
+          {{#if this.authenticationEnabled}}
+            <AuthenticationConfiguration
+              @options={{this.securitySchemesOptions}}
+              @selected={{this.selectedSecurityScheme}}
+              @onChange={{this.setSecurityScheme}}
+              @credentials={{this.credentials}}
+              @securityScheme={{this.securityScheme}}
+              @onCredentialsChange={{this.updateCredentials}}
+              @onSecuritySchemeChange={{this.updateSecurityScheme}}
+            />
+          {{/if}}
+          <AuButton
+            class="au-u-margin-top-large"
+            {{on 'click' this.scheduleHarvestJob}}
+            @disabled={{this.scheduling}}
+            @loading={{this.scheduling}}
+            @loadingMessage="Scheduling">
+            Schedule
+          </AuButton>
         {{/if}}
       </div>
     </div>
   </div>
 </div>
-
-<AuToolbar @border="top" @size="large">
-  {{#if this.success}}
-  <AuToolbarGroup class="au-c-toolbar__group--row">
-    <AuAlert class="au-u-margin-top-large" @alertIcon="check" @alertTitle="Job succesfully scheduled"
-      @alertskin={{"success"}}>
-    </AuAlert>
-  </AuToolbarGroup>
-  {{else if this.error}}
-  <AuToolbarGroup class="au-c-toolbar__group--row">
-    <AuAlert class="au-u-margin-top-large" @alertIcon="cross" @alertTitle="Something went wrong" @alertskin={{"error"}}>
-      {{this.errorMessage}}
-    </AuAlert>
-  </AuToolbarGroup>
-  {{/if}}
-</AuToolbar>

--- a/app/templates/scheduled-jobs/new.hbs
+++ b/app/templates/scheduled-jobs/new.hbs
@@ -81,25 +81,16 @@
             @onSecuritySchemeChange={{this.updateSecurityScheme}}
           />
         {{/if}}
-        <AuButton class="au-u-margin-top-large" @disabled={{not this.isValidCron}} {{on 'click' this.createScheduledJob}}>Schedule</AuButton>
+        <AuButton
+          class="au-u-margin-top-large"
+          {{on 'click' this.createScheduledJob}}
+          @disabled={{(or this.scheduling (not this.isValidCron))}}
+          @loading={{this.scheduling}}
+          @loadingMessage="Scheduling">
+          Schedule
+        </AuButton>
         {{/if}}
       </div>
     </div>
   </div>
 </div>
-
-<AuToolbar @border="top" @size="large">
-  {{#if this.success}}
-  <AuToolbarGroup class="au-c-toolbar__group--row">
-    <AuAlert class="au-u-margin-top-large" @alertIcon="check" @alertTitle="Job succesfully scheduled"
-      @alertskin={{"success"}}>
-    </AuAlert>
-  </AuToolbarGroup>
-  {{else if this.error}}
-  <AuToolbarGroup class="au-c-toolbar__group--row">
-    <AuAlert class="au-u-margin-top-large" @alertIcon="cross" @alertTitle="Something went wrong" @alertskin={{"error"}}>
-      {{this.errorMessage}}
-    </AuAlert>
-  </AuToolbarGroup>
-  {{/if}}
-</AuToolbar>

--- a/app/templates/scheduled-jobs/new.hbs
+++ b/app/templates/scheduled-jobs/new.hbs
@@ -84,7 +84,7 @@
         <AuButton
           class="au-u-margin-top-large"
           {{on 'click' this.createScheduledJob}}
-          @disabled={{(or this.scheduling (not this.isValidCron))}}
+          @disabled={{or this.scheduling (not this.isValidCron)}}
           @loading={{this.scheduling}}
           @loadingMessage="Scheduling">
           Schedule


### PR DESCRIPTION
This PR puts the buttons that schedule Jobs in a loading state if the jobs are being created. After creation, you get a toaster message and the application transitions back to the overview.

This is a primitive solution to the problem where rapid firing the buttons would schedule multiple jobs for the same URI. Harvesting the same URI leads to unexpected behaviour and this is a first attempt at stopping this from happening.

**How to test:** create a job or scheduled job as usual and while it is being scheduled, notice the button state and the automatic transitioning. Also notice the toast message in the top right or the screen. Make sure the schedule button is available for the next job scheduling.