### PR TITLE
Fix duplicated tasks

### DIFF
--- a/app/controllers/jobs/new.js
+++ b/app/controllers/jobs/new.js
@@ -91,7 +91,9 @@ export default class JobsNewController extends Controller {
 
     const remoteDataObject = this.store.createRecord('remote-data-object', {
       source: this.url,
-      status: null, // this is deliberate, cf. infra when saving everything
+      // This is deliberate, the collector service will set the status and
+      // therefore start the job later:
+      status: undefined,
       requestHeader: 'http://data.lblod.info/request-headers/accept/text/html',
       created: this.currentTime,
       modified: this.currentTime,
@@ -131,12 +133,6 @@ export default class JobsNewController extends Controller {
       await collection.save();
       await dataContainer.save();
       await task.save();
-      // This a huge abstraction leak we need to tackle one day
-      // Basically we are coordinating deltas when the download should start, after all the rest of the data
-      // is created. Else we have a timing issue, i.e. the downlad ready, before all other meta-data was created.
-      remoteDataObject.status =
-        'http://lblod.data.gift/file-download-statuses/ready-to-be-cached';
-      await remoteDataObject.save();
 
       this.toaster.success(
         'New job succesfully scheduled.',

--- a/app/controllers/scheduled-jobs/new.js
+++ b/app/controllers/scheduled-jobs/new.js
@@ -117,8 +117,7 @@ export default class ScheduledJobsNewController extends Controller {
 
     const remoteDataObject = this.store.createRecord('remote-data-object', {
       source: this.url,
-      status:
-        'http://lblod.data.gift/file-download-statuses/ready-to-be-cached',
+      status: undefined,
       requestHeader: 'http://data.lblod.info/request-headers/accept/text/html',
       created: this.currentTime,
       modified: this.currentTime,


### PR DESCRIPTION
The collector service schedules a download task by putting the `ready-to-be-cached` status on a `RemoteDataObject`. If the frontend also does that, you end up with a concurrency issue that would duplicate the rest of the tasks. This issue doesn't always occur as it depends on the speed of the messages and the timing of the delta-notifier.

This PR fixes the problem by simply not setting the status of the `RemoteDataObject`. The collector service will do that later.

**How to test:** not sure if you can even reproduce the problem on any computer, but retry harvesting the same document over over again and see if you get multiple duplicated tasks. After applying this PR, you don't get that anymore.