### PR TITLE
Deleting authenticationConfiguration and nested relationships

### DIFF
--- a/app/controllers/scheduled-job/details.js
+++ b/app/controllers/scheduled-job/details.js
@@ -32,34 +32,68 @@ export default class ScheduledJobDetailsController extends Controller {
     //NOTE: Even though inputContainers & resultsContainers have the same
     //nested structure, I duplicated the code since I know you like the
     //seperation more then a wrapping |for| loop
+
+    // NOTE : Modified the code to delete from bottom to top because currently
+    // there is no deletion of the authenticationConfiguration and
+    // informations attached(securityScheme and credential). We need
+    // to get this deleted because it shouldn't stay in the db even
+    // if the job is deleted
     const scheduledTasks = yield this.job.scheduledTasks;
+    yield this.deleteTaskAndAllRelatedData.perform(scheduledTasks);
     yield this.job.destroyRecord();
-
-    for (const task of scheduledTasks) {
-      const iContainers = yield task.inputContainers;
-      yield task.destroyRecord();
-
-      for (const input of iContainers) {
-        const fileList = yield input.files;
-        const collectionList = yield input.harvestingCollections;
-        yield input.destroyRecord();
-
-        for (const file of fileList) {
-          //NOTE: file model gets found but cannot get physical file in backend
-          //to delete
-          yield file.destroyRecord();
-        }
-
-        for (const collection of collectionList) {
-          const rObjs = yield collection.remoteDataObjects;
-          yield collection.destroyRecord();
-
-          for (const rObj of rObjs) {
-            yield rObj.destroyRecord();
-          }
-        }
-      }
-    }
     this.router.transitionTo('overview.scheduled-jobs');
+  }
+
+  @task
+  *deleteTaskAndAllRelatedData(tasks) {
+    for (const task of tasks) {
+      const inputContainers = yield task.inputContainers;
+      yield this.deleteInputContainersAndAllRelatedData.perform(
+        inputContainers
+      );
+      yield task.destroyRecord();
+    }
+  }
+
+  @task
+  *deleteInputContainersAndAllRelatedData(inputContainers) {
+    for (const input of inputContainers) {
+      const fileList = yield input.files;
+      const collectionList = yield input.harvestingCollections;
+
+      for (const file of fileList) {
+        //NOTE: file model gets found but cannot get physical file in backend
+        // to delete
+        yield file.destroyRecord();
+      }
+
+      yield this.deleteCollectionsAndAllRelatedData.perform(collectionList);
+      yield input.destroyRecord();
+    }
+  }
+
+  @task
+  *deleteCollectionsAndAllRelatedData(collections) {
+    for (const collection of collections) {
+      const rObjs = yield collection.remoteDataObjects;
+      const authConfigObj = yield collection.authenticationConfiguration;
+
+      if (authConfigObj) {
+        const credential = yield authConfigObj.credential;
+        const scheme = yield authConfigObj.securityScheme;
+
+        yield credential.destroyRecord();
+
+        yield scheme.destroyRecord();
+
+        yield authConfigObj.destroyRecord();
+      }
+
+      for (const rObj of rObjs) {
+        yield rObj.destroyRecord();
+      }
+
+      yield collection.destroyRecord();
+    }
   }
 }


### PR DESCRIPTION
# Description
DL-5039

This PR is about deleting the authenticationConfiguration from the database and everything nested, like credential and securityScheme.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [scheduled-job-controller-service](https://github.com/lblod/scheduled-job-controller-service)

# How to test

`app-worship-harvester` needs authentication.

Please make sure you have in your migration folder : 2023/local/`20230309104958-add-mock-user.sparql`.
You can find this migration on the development server from the `app-worship-harvester-qa`. Also you need to enable from the frontend container the variable `EMBER_AUTHENTICATION_ENABLED: 'true'`

You will need to create a docker-compose.override.yml file with the following images : 
- `poltergeistz/scheduled-job-controller-service-local:latest`
- `poltergeistz/frontend-harvesting-self-service-local:latest`

Here's a base you can follow :

```yml
version: "3.7"

services:
  frontend:
      image: poltergeistz/frontend-harvesting-self-service-local:latest
      environment:
        EMBER_AUTHENTICATION_ENABLED: 'true'
  scheduled-job-controller-service:
      image: poltergeistz/scheduled-job-controller-service-local:latest
``` 

For the login information it should be the same as QA.

You can now start the app and login.

## What to check

BASIC_AUTH

```sparql
PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
SELECT DISTINCT * WHERE {
  <REPLACE_THIS_BY_THE_AUTHENTICATION_CONFIGURATION_URI> dgftSec:secrets ?secrets .
          ?secrets meb:username ?user ;
            muAccount:password ?pass .
} 
```

OAUTH2

```sparql
PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
PREFIX dgftOauth: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
SELECT DISTINCT * WHERE {
   <REPLACE_THIS_BY_THE_AUTHENTICATION_CONFIGURATION_URI> dgftSec:secrets ?secrets .
          ?secrets dgftOauth:clientId ?clientId ;
            dgftOauth:clientSecret ?clientSecret .
   <REPLACE_THIS_BY_THE_AUTHENTICATION_CONFIGURATION_URI> dgftSec:securityConfiguration ?scheme .
         ?scheme wotSec:token ?token ;
            wotSec:flow ?flow .
}
```
- When deleting a scheduled job, the authentication configuration from the source collection (the one attached to the scheduled job) should not contain any credential data and securityScheme. Querying it should not return anything.

# Links to other PR's

- https://github.com/lblod/scheduled-job-controller-service/pull/2