### PR TITLE
New env variable to hide job delete button

### DIFF
--- a/app/controllers/job/tasklist.js
+++ b/app/controllers/job/tasklist.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { service } from '@ember/service';
 import { task } from 'ember-concurrency-decorators';
 import { action } from '@ember/object';
-
+import config from 'frontend-harvesting-self-service/config/environment';
 export default class JobTasklistController extends Controller {
   @service router;
 
@@ -12,6 +12,12 @@ export default class JobTasklistController extends Controller {
   size = 15;
 
   @tracked job;
+
+  get hideDeleteJobButton() {
+    return ['true', 'True', 'TRUE', true].includes(
+      config.harvester.hideDeleteJobButton
+    );
+  }
 
   @action
   reload() {

--- a/app/templates/job/tasklist.hbs
+++ b/app/templates/job/tasklist.hbs
@@ -49,7 +49,7 @@
                 <dt class="au-u-bold">Comments</dt>
                 <dd>{{this.job.comment}}</dd>
               </div>
-            {{/if}} 
+            {{/if}}
             {{#if this.job.error.message}}
               <div>
                 <dt class="au-u-hidden-visually">Errors</dt>
@@ -68,6 +68,7 @@
         </div>
       </div>
       <div class="au-c-sidebar__footer">
+      {{#unless this.hideDeleteJobButton}}
         <AuButton
           @skin="primary"
           @icon="trash"
@@ -80,6 +81,7 @@
           {{on "click" (perform this.deleteJob this.job)}}>
           Delete
         </AuButton>
+      {{/unless}}
       </div>
     </div>
   </m.sidebar>

--- a/config/environment.js
+++ b/config/environment.js
@@ -15,6 +15,7 @@ module.exports = function (environment) {
       authEnabled: '{{AUTHENTICATION_ENABLED}}',
       besluitenHarvesting: '{{BESLUITEN_HARVESTING_ENABLED}}',
       worshipHarvesting: '{{WORSHIP_HARVESTING_ENABLED}}',
+      hideDeleteJobButton: '{{HIDE_DELETE_JOB_BUTTON_ENABLED}}',
     },
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
# Description
BNB-834
Currently, the delete button is visible on the job detail page in the Harvester. Since the delete functionality is not yet properly implemented, we want to temporarily hide this button.

Take this ticket as an opportunity to set up the Harvester locally and get familiar with it. Let me or Aad know if you run into any issues!

Acceptance Criteria:

The delete button is no longer visible on the job detail page.

# How to test
### To test in the frontend 
- Go to `envionment.js` and set the `hideDeleteJobButton` on line 18 to `true`

```diff
    harvester: {
      authEnabled: '{{AUTHENTICATION_ENABLED}}',
      besluitenHarvesting: '{{BESLUITEN_HARVESTING_ENABLED}}',
      worshipHarvesting: '{{WORSHIP_HARVESTING_ENABLED}}',
-    hideDeleteJobButton: '{{HIDE_DELETE_JOB_BUTTON_ENABLED}}',
+    hideDeleteJobButton: true
    }
```

### To test in the backend 
- Go to `docker-compose.yml` file and add 
```diff
  frontend:
    image: lblod/frontend-harvesting-self-service:latest
    volumes:
      - ./config/frontend:/config
    labels:
      - "logging=true"
    restart: always
    logging: *default-logging
    environment:
      EMBER_AUTHENTICATION_ENABLED: "true"
+    EMBER_HIDE_DELETE_JOB_BUTTON_ENABLED: "true" 
```

## What to check
- Delete job button is hidden when environment variable is set to true
- No other functionality is impacted.




