### PR TITLE
pdf pipeline: list of municipalities

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -56,9 +56,9 @@ export default class OverviewJobsNewController extends Controller {
   @tracked codelistUri;
   @tracked codelistUriValid = true;
 
-  @tracked loadingGoverningBodies = false;
-  @tracked governingBodies = [];
-  @tracked selectedGoverningBody;
+  @tracked loadingMunicipalities = false;
+  @tracked municipalities = [];
+  @tracked selectedMunicipality;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
@@ -93,19 +93,18 @@ export default class OverviewJobsNewController extends Controller {
 
     if (selected?.uri === cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI) {
       this.loadingOrganizations = true;
-      this.governingBodies = await this.store.query('organization', {
+      this.municipalities = await this.store.query('organization', {
+        page: { size: 600 },
         filter: {
-          ':has:sub-organization-of': 't',
-          'sub-organization-of': {
-            classification:
-              'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
-          },
+          classification:
+            'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
         },
+        sort: ':no-case:pref-label',
       });
       this.loadingOrganizations = false;
     } else {
-      this.governingBodies = [];
-      this.selectedGoverningBody = null;
+      this.municipalities = [];
+      this.selectedMunicipality = null;
     }
   }
 
@@ -119,8 +118,8 @@ export default class OverviewJobsNewController extends Controller {
   noop() {}
 
   @action
-  changeSelectedGoverningBody(org) {
-    this.selectedGoverningBody = org;
+  changeSelectedMunicipality(org) {
+    this.selectedMunicipality = org;
   }
 
   @action
@@ -195,7 +194,7 @@ export default class OverviewJobsNewController extends Controller {
       await scheduledJob.save();
 
       const inputContainers = [];
-      let dataContainer, dataContainerWithGoverningBody;
+      let dataContainer, dataContainerWithMunicipality;
       if (this.selectedJobOperation.uri === this.jobImport) {
         dataContainer = this.store.createRecord('data-container', {
           hasGraph: this.graphName,
@@ -241,15 +240,15 @@ export default class OverviewJobsNewController extends Controller {
         inputContainers.push(dataContainer);
 
         if (this.selectedJobOperation.uri === this.jobHarvestPdfToELI) {
-          dataContainerWithGoverningBody = this.store.createRecord(
+          dataContainerWithMunicipality = this.store.createRecord(
             'data-container',
             {
-              hasResource: [this.selectedGoverningBody.uri],
+              hasResource: [this.selectedMunicipality.uri],
             },
           );
 
-          await dataContainerWithGoverningBody.save();
-          inputContainers.push(dataContainerWithGoverningBody);
+          await dataContainerWithMunicipality.save();
+          inputContainers.push(dataContainerWithMunicipality);
         }
       }
 

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -139,13 +139,15 @@
 
           {{#if (eq this.selectedJobOperation.uri this.jobHarvestPdfToELI)}}
             <AuFormRow @alignment="default">
-              <AuLabel for="decision-passed-by">  
+              <AuLabel for="decision-passed-by">
                 Municipality
               </AuLabel>
               <PowerSelect
                 id="decision-passed-by"
+                @searchEnabled={{true}}
+                @searchField="label"
                 @options={{this.municipalities}}
-                @selected={{this.selectedMunicipality}}  
+                @selected={{this.selectedMunicipality}}
                 @onChange={{this.changeSelectedMunicipality}}
                 @renderInPlace={{true}}
                 @disabled={{or this.loadingMunicipalities (not this.municipalities.length)}}

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -140,21 +140,18 @@
           {{#if (eq this.selectedJobOperation.uri this.jobHarvestPdfToELI)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decision-passed-by">  
-                Passed by
+                Municipality
               </AuLabel>
               <PowerSelect
                 id="decision-passed-by"
-                @options={{this.governingBodies}}
-                @selected={{this.selectedGoverningBody}}  
-                @onChange={{this.changeSelectedGoverningBody}}
+                @options={{this.municipalities}}
+                @selected={{this.selectedMunicipality}}  
+                @onChange={{this.changeSelectedMunicipality}}
                 @renderInPlace={{true}}
-                @disabled={{or this.loadingGoverningBodies (not this.governingBodies.length)}}
+                @disabled={{or this.loadingMunicipalities (not this.municipalities.length)}}
                 as |option|>
                 {{option.label}}
               </PowerSelect>
-              <AuHelpText @warning={{true}}>
-                The governing body that originally passed or made the decision.
-              </AuHelpText>
             </AuFormRow>
           {{/if}}
 


### PR DESCRIPTION
# Context
Before in the PDF to ELI pipeline, we listed governing bodies that "passed by" the decision.
Now, the frontend lists municipalities instead of governing bodies.
The label of the municipality is used by the NEL service as "location" to link governing bodies or mandatees with their URI to the decision. So it would defeat the purpose of the NEL and require more effort from the user to select the governing body.

# To test

Make sure backend of app-decide is running.
Run `npm run dev:proxy` or `ember serve --environment=development --proxy=http://dashboard.localhost:80` for the dashboard

First, municipalities must have been added:
* Migrations must have ran in order to list the municipality "Ghent".
* For municipality "Freiburg", you must run the Oparl pipeline:
create a job "Harvest OParl API & Publish as ELI" with URL `https://ris.freiburg.de/oparl`.

Then,
create a new "PDF to ELI" job, there you should see "Freiburg", and/or "Ghent" under Municipality: `http://localhost:4200/overview/jobs/new`:
<img width="787" height="839" alt="image" src="https://github.com/user-attachments/assets/d9d1f341-ada1-432e-83e4-71bdcf6fe8c3" />



