### PR TITLE
Lbron 965 v3 pdf scraper multi

### DIFF
--- a/app/components/scheduled-job-endpoint.hbs
+++ b/app/components/scheduled-job-endpoint.hbs
@@ -1,10 +1,22 @@
-{{#if this.loadEndpoint.isRunning}}
+{{#if this.loadEndpoints.isRunning}}
   <div class="au-u-flex au-u-flex--vertical-center">
     <AuIcon @icon="loading" @size="small" @spin={{true}} />
     <span class="au-u-margin-left-tiny au-u-text-muted">Loading...</span>
   </div>
-{{else if this.endpoint}}
-  {{this.endpoint}}
+{{else if this.endpoints}}
+  <ul class="au-u-margin-top-small">
+    {{#each this.endpoints as |endpoint|}}
+      <li>
+        <AuLinkExternal
+          href={{endpoint}}
+          @newTab={{true}}
+          @width={{this.width}}
+        >
+          {{endpoint}}
+        </AuLinkExternal>
+      </li>
+    {{/each}}
+  </ul>
 {{else}}
-  <span class="au-u-text-muted">No endpoint found</span>
+  <span class="au-u-text-muted">No endpoints found</span>
 {{/if}}

--- a/app/components/scheduled-job-endpoint.js
+++ b/app/components/scheduled-job-endpoint.js
@@ -6,14 +6,14 @@ import { task } from 'ember-concurrency';
 export default class ScheduledJobEndpointComponent extends Component {
   @service store;
 
-  @tracked endpoint = null;
+  @tracked endpoints = [];
 
   constructor() {
     super(...arguments);
-    this.loadEndpoint.perform();
+    this.loadEndpoints.perform();
   }
 
-  loadEndpoint = task(async () => {
+  loadEndpoints = task(async () => {
     if (!this.args.scheduledJob) {
       return;
     }
@@ -34,9 +34,8 @@ export default class ScheduledJobEndpointComponent extends Component {
             const firstCollection = harvestingCollections[0];
             const remoteDataObjects = await firstCollection.remoteDataObjects;
 
-            if (remoteDataObjects.length > 0) {
-              const firstRemoteDataObject = remoteDataObjects[0];
-              this.endpoint = firstRemoteDataObject.source;
+            if (remoteDataObjects.length >= 1) {
+              this.endpoints = remoteDataObjects.map((rdo) => rdo.source);
             }
           }
         }

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -74,6 +74,10 @@ export default class OverviewJobsNewController extends Controller {
     return new Date();
   }
 
+  get isJobWithMultipleEndpoints() {
+    return this.selectedJobOperation?.uri === this.jobPdfScraping;
+  }
+
   @action
   updateCredentials(attributeName, credentials) {
     this.credentials[attributeName] = credentials;

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -6,6 +6,7 @@ import { service } from '@ember/service';
 import createAuthenticationConfiguration from '../../../utils/create-authentication-configuration';
 import config from 'frontend-harvesting-self-service/config/environment';
 import * as cts from '../../../utils/constants';
+import { isValidUrl } from '../../../utils/string-validation';
 
 export default class OverviewJobsNewController extends Controller {
   jobHarvest = cts.JOB_OP_TYPE_HARVEST;
@@ -208,7 +209,11 @@ export default class OverviewJobsNewController extends Controller {
         }
         if (this.selectedJobOperation.uri === this.jobPdfScraping) {
           const newLinePattern = /\r?\n/;
-          sources = this.url.split(newLinePattern);
+          sources = this.url.split(newLinePattern).map((source) => {
+            if (!isValidUrl(source)) {
+              throw new Error(`"${source}" is not a valid url.`);
+            }
+          });
         }
 
         const remoteDataObjects = sources.map((source) => {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -16,6 +16,7 @@ export default class OverviewJobsNewController extends Controller {
   jobCodelistMapping = cts.JOB_OP_TYPE_CODELIST_MAPPING;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
+  jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
 
   @tracked jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(
     ([key, value]) => {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -202,24 +202,31 @@ export default class OverviewJobsNewController extends Controller {
         });
         await dataContainer.save();
       } else {
-        const source =
-          this.selectedJobOperation.uri === this.jobCodelistMapping
-            ? shapeForTargets.uri
-            : this.url.trim();
+        let sources = [this.url.trim()];
+        if (this.selectedJobOperation.uri === this.jobCodelistMapping) {
+          sources = [shapeForTargets.uri];
+        }
+        if (this.selectedJobOperation.uri === this.jobPdfScraping) {
+          const newLinePattern = /\r?\n/;
+          sources = this.url.split(newLinePattern);
+        }
 
-        const remoteDataObject = this.store.createRecord('remote-data-object', {
-          source,
-          // This is deliberate, the collector service will set the status and
-          // therefore start the job later:
-          status: undefined,
-          requestHeader:
-            'http://data.lblod.info/request-headers/accept/text/html',
-          created: this.currentTime,
-          modified: this.currentTime,
-          creator: this.creator,
+        const remoteDataObjects = sources.map((source) => {
+          return this.store.createRecord('remote-data-object', {
+            source,
+            // This is deliberate, the collector service will set the status and
+            // therefore start the job later:
+            status: undefined,
+            requestHeader:
+              'http://data.lblod.info/request-headers/accept/text/html',
+            created: this.currentTime,
+            modified: this.currentTime,
+            creator: this.creator,
+          });
         });
-        await remoteDataObject.save();
-
+        await Promise.all(
+          remoteDataObjects.map(async (rdo) => await rdo.save()),
+        );
         const collection = this.store.createRecord('harvesting-collection', {
           creator: this.creator,
           authenticationConfiguration: this.selectedSecurityScheme
@@ -230,7 +237,7 @@ export default class OverviewJobsNewController extends Controller {
                 this.store,
               )
             : null, // authenticationConfiguration is optional
-          remoteDataObjects: [remoteDataObject],
+          remoteDataObjects: remoteDataObjects,
         });
         await collection.save();
 

--- a/app/controllers/overview/scheduled-jobs/details/edit.js
+++ b/app/controllers/overview/scheduled-jobs/details/edit.js
@@ -41,6 +41,14 @@ export default class OverviewScheduledJobsDetailsEditController extends Controll
     }
   }
 
+  get isEndpointInputShown() {
+    return (
+      this.hasEndpoint &&
+      !this.job.isConsumerDeltaSyncJob &&
+      !this.job.isJobWithMultipleEndpoints
+    );
+  }
+
   @action
   cancelEditScheduledJob() {
     this.router.transitionTo('overview.scheduled-jobs.details');

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -148,17 +148,23 @@ export default class OverviewScheduledJobsNewController extends Controller {
         schedule: cronSchedule,
         vendor: this.vendor,
       });
-
-      const remoteDataObject = this.store.createRecord('remote-data-object', {
-        source: this.url,
-        status: undefined,
-        requestHeader:
-          'http://data.lblod.info/request-headers/accept/text/html',
-        created: this.currentTime,
-        modified: this.currentTime,
-        creator: this.creator,
+      let sources = [this.url.trim()];
+      if (this.selectedJobOperation.uri === this.jobPdfScraping) {
+        const newLinePattern = /\r?\n/;
+        sources = this.url.split(newLinePattern);
+      }
+      const remoteDataObjects = sources.map((source) => {
+        return this.store.createRecord('remote-data-object', {
+          source: source,
+          status: undefined,
+          requestHeader:
+            'http://data.lblod.info/request-headers/accept/text/html',
+          created: this.currentTime,
+          modified: this.currentTime,
+          creator: this.creator,
+        });
       });
-
+      await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
       const collection = this.store.createRecord('harvesting-collection', {
         creator: this.creator,
         //TODO: authentication configuration doesn't work currently for scheduled jobs. Because
@@ -172,7 +178,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
               this.store,
             )
           : null, // authenticationConfiguration is optional
-        remoteDataObjects: [remoteDataObject],
+        remoteDataObjects: remoteDataObjects,
       });
 
       const dataContainer = this.store.createRecord('data-container', {
@@ -189,14 +195,13 @@ export default class OverviewScheduledJobsNewController extends Controller {
       });
 
       await cronSchedule.save();
-      await remoteDataObject.save();
       await collection.save();
       await dataContainer.save();
       await scheduledJob.save();
       await scheduledTask.save();
 
       this.toaster.success(
-        'New job succesfully scheduled.',
+        'New job successfully scheduled.',
         'Scheduling success',
         { icon: 'check', timeOut: 10000, closable: true },
       );

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -8,6 +8,7 @@ import cronstrue from 'cronstrue';
 import createAuthenticationConfiguration from '../../../utils/create-authentication-configuration';
 import config from 'frontend-harvesting-self-service/config/environment';
 import * as cts from '../../../utils/constants';
+import { isValidUrl } from '../../../utils/string-validation';
 
 export default class OverviewScheduledJobsNewController extends Controller {
   jobHarvest = cts.JOB_OP_TYPE_HARVEST;
@@ -151,7 +152,11 @@ export default class OverviewScheduledJobsNewController extends Controller {
       let sources = [this.url.trim()];
       if (this.selectedJobOperation.uri === this.jobPdfScraping) {
         const newLinePattern = /\r?\n/;
-        sources = this.url.split(newLinePattern);
+        sources = this.url.split(newLinePattern).map((source) => {
+          if (!isValidUrl(source)) {
+            throw new Error(`Value: "${source}" is not a valid url.`);
+          }
+        });
       }
       const remoteDataObjects = sources.map((source) => {
         return this.store.createRecord('remote-data-object', {

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -80,6 +80,10 @@ export default class OverviewScheduledJobsNewController extends Controller {
     return timestamp;
   }
 
+  get isJobWithMultipleEndpoints() {
+    return this.selectedJobOperation?.uri === this.jobPdfScraping;
+  }
+
   @action
   updateCredentials(attributeName, credentials) {
     this.credentials[attributeName] = credentials;

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -15,6 +15,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobHarvestWorship = cts.JOB_OP_TYPE_HARVEST_WORSHIP;
   jobHarvestWorshipAndImport = cts.JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
+  jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
 
   jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(([key, value]) => {
     return { label: value, uri: key };

--- a/app/models/scheduled-job.js
+++ b/app/models/scheduled-job.js
@@ -18,4 +18,8 @@ export default class ScheduledJobModel extends Model {
   get isConsumerDeltaSyncJob() {
     return this.operation === cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   }
+
+  get isJobWithMultipleEndpoints() {
+    return this.operation === cts.JOB_OP_TYPE_PDF_SCRAPING;
+  }
 }

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -118,6 +118,26 @@
                 </Group.Radio>
               </AuRadioGroup>
             </AuFormRow>
+          {{else if (eq this.selectedJobOperation.uri this.jobPdfScraping)}}
+            <AuFormRow @alignment="default">
+              <AuLabel
+                for="task-url"
+                @required={{true}}
+                @requiredLabel="Required"
+                @error={{not this.urlValid}}>
+                URL's
+              </AuLabel>
+              <AuTextarea
+                id="task-url"
+                @width="block"
+                value={{this.url}}
+                @error={{not this.urlValid}}
+                {{on "change" (fn this.setProperty "url")}}
+              />
+              <AuHelpText>
+                All url values in this input should be separated by a new-line
+              </AuHelpText>
+            </AuFormRow>
           {{else}}
             <AuFormRow @alignment="default">
               <AuLabel

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -118,7 +118,7 @@
                 </Group.Radio>
               </AuRadioGroup>
             </AuFormRow>
-          {{else if (eq this.selectedJobOperation.uri this.jobPdfScraping)}}
+          {{else if this.isJobWithMultipleEndpoints}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="task-url"

--- a/app/templates/overview/scheduled-jobs/details/edit.hbs
+++ b/app/templates/overview/scheduled-jobs/details/edit.hbs
@@ -24,7 +24,7 @@
            @error={{not this.newTitleValid}} />
       </AuFormRow>
 
-      {{#if (and this.hasEndpoint (not this.job.isConsumerDeltaSyncJob))}}
+      {{#if this.isEndpointInputShown}}
         <AuFormRow @alignment="default">
           <AuLabel
             for="task-endpoint"
@@ -40,6 +40,15 @@
             {{on "change" this.setEndpoint}}
              @error={{not this.newEndpointValid}} />
         </AuFormRow>
+      {{/if}}
+
+      {{#if this.job.isJobWithMultipleEndpoints}}
+        <AuLabel>
+          Endpoints
+        </AuLabel>
+        <AuAlert @icon="info-circle" @skin="warning" @size="small">
+          Editing the endpoints of this job is currently not supported
+        </AuAlert>
       {{/if}}
 
       <AuFormRow @alignment="default">

--- a/app/templates/overview/scheduled-jobs/details/index.hbs
+++ b/app/templates/overview/scheduled-jobs/details/index.hbs
@@ -44,7 +44,7 @@
             <dt class="au-u-bold">Sync mode</dt>
             <dd>Delta sync</dd>
             {{else}}
-            <dt class="au-u-bold">Endpoint</dt>
+            <dt class="au-u-bold">Endpoints</dt>
             <dd>
               <ScheduledJobEndpoint @scheduledJob={{this.job}} />
             </dd>

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -91,6 +91,26 @@
                 Initial sync is a one-time run and should be started as a single harvesting job. A scheduled job for delta sync is ideal to keep data up to date.
               </AuHelpText>
             </AuFormRow>
+        {{else if (eq this.selectedJobOperation.uri this.jobPdfScraping)}}
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="task-url"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.urlValid}}>
+              URL's
+            </AuLabel>
+            <AuTextarea
+              id="task-url"
+              @width="block"
+              value={{this.url}}
+              @error={{not this.urlValid}}
+              {{on "change" (fn this.setProperty "url")}}
+            />
+            <AuHelpText>
+              All url values in this input should be separated by a new-line
+            </AuHelpText>
+          </AuFormRow>
         {{else}}
           <AuFormRow @alignment="default">
             <AuLabel

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -91,7 +91,7 @@
                 Initial sync is a one-time run and should be started as a single harvesting job. A scheduled job for delta sync is ideal to keep data up to date.
               </AuHelpText>
             </AuFormRow>
-        {{else if (eq this.selectedJobOperation.uri this.jobPdfScraping)}}
+        {{else if this.isJobWithMultipleEndpoints}}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-url"

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -26,6 +26,8 @@ export const JOB_OP_TYPE_HARVESTING_OPARL =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/oparl';
 export const JOB_OP_TYPE_HARVESTING_PDF_TO_ELI =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-eli';
+export const JOB_OP_TYPE_PDF_SCRAPING =
+  'http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping';
 export const JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/oslo-to-eli';
 export const JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS =
@@ -68,6 +70,7 @@ JOB_OP_TYPES.set(
 );
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OPARL, 'Harvest OParl API & Publish');
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_PDF_TO_ELI, 'Harvest PDF to ELI');
+JOB_OP_TYPES.set(JOB_OP_TYPE_PDF_SCRAPING, 'PDF url scraping');
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI, 'Harvest OSLO to ELI');
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS,
@@ -75,6 +78,7 @@ JOB_OP_TYPES.set(
 );
 JOB_OP_TYPES.set(JOB_OP_TYPE_ELI_ENTITY_LINKING_TEST, 'Entity Linking test');
 JOB_OP_TYPES.set(JOB_OP_TYPE_CODELIST_MAPPING, 'Codelist mapping');
+
 export const JOB_OP_TYPE_CREATE = new Map();
 
 if (
@@ -104,6 +108,7 @@ if (['true', 'True', 'TRUE', true].includes(config.harvester.pdfHarvesting)) {
     JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
     'Harvest PDF & Publish as ELI',
   );
+  JOB_OP_TYPE_CREATE.set(JOB_OP_TYPE_PDF_SCRAPING, 'PDF url scraping');
 }
 if (['true', 'True', 'TRUE', true].includes(config.harvester.osloHarvesting)) {
   JOB_OP_TYPE_CREATE.set(

--- a/app/utils/string-validation.js
+++ b/app/utils/string-validation.js
@@ -1,0 +1,9 @@
+export function isValidUrl(urlAsString) {
+  if (!urlAsString) {
+    return false;
+  }
+
+  const urlRegex =
+    /^((http|https):\/\/(\w+:{0,1}\w*@)?(\S+)|)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-/]))?$/;
+  return String(urlAsString).match(urlRegex) !== null;
+}


### PR DESCRIPTION
## 🗒️ Description
When the job is pdf scraping we would like to support multiple url's as input. Editing the endpoints of a job should not be possible.

## 🦮 How to test

Use latest image of [semantic-ai/pdf-scraper](https://github.com/semantic-ai/decide-pdf-scraper)
Run the frontend with `npm run dev:proxy`

1. Create a standalone job (single and multi url)
2. Create a schedled job (single and multi url)
3. Error should occur if value of url does not match the regex

- I used this link from the pdf-scraper repo example as endpoint
  - https://district09.gent/nl/over-ons/wettelijke-documenten/besluiten-overlegorgaan
  - https://district09.gent/nl/over-ons/wettelijke-documenten

## 🔗 Links to other PR's

- https://github.com/semantic-ai/decide-pdf-scraper/pull/1

## 🖼️ Attachments

- scheduled job endpoints
<img width="1091" height="725" alt="image" src="https://github.com/user-attachments/assets/f45b579d-8ba2-48a0-b99e-7f40b9f33655" />


- Edit of multi url not possible
<img width="817" height="561" alt="image" src="https://github.com/user-attachments/assets/ca74d8fd-7b50-4e07-8485-a350c43ca3e3" />

- Add the links with new lines
<img width="819" height="871" alt="image" src="https://github.com/user-attachments/assets/0475ff95-7956-459d-adfe-8e860ba60ad3" />

- Small validation on url
<img width="997" height="535" alt="image" src="https://github.com/user-attachments/assets/57a3a380-4788-4a0f-8483-8e1bad20cdc0" />
