### PR TITLE
Extend codelist mapping UI for annotation/training jobs

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -195,8 +195,7 @@ export default class OverviewJobsNewController extends Controller {
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetClass: [
-              // Alternative: 'http://data.vlaanderen.be/ns/besluit#Besluit',
-              'http://data.europa.eu/eli/ontology#LegalExpression',
+              'http://data.europa.eu/eli/ontology#Expression',
             ],
           });
         }

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -57,6 +57,10 @@ export default class OverviewJobsNewController extends Controller {
   @tracked decisionUriValid;
   @tracked codelistUri;
   @tracked codelistUriValid = true;
+  @tracked graphForTargetsUri;
+  @tracked graphForTargetsUriValid;
+  @tracked propertyPathForTextUri;
+  @tracked propertyPathForTextUriValid;
 
   @tracked loadingMunicipalities = false;
   @tracked municipalities = [];
@@ -141,6 +145,8 @@ export default class OverviewJobsNewController extends Controller {
     else this.vendorValid = false;
     this.decisionUriValid = true;
     this.codelistUriValid = !!this.codelistUri;
+    this.graphForTargetsUriValid = true;
+    this.propertyPathForTextUriValid = true;
 
     if (!this.selectedJobOperation) return false;
     if (this.selectedJobOperation.uri === this.jobImport)
@@ -149,7 +155,9 @@ export default class OverviewJobsNewController extends Controller {
       return (
         this.selectedJobOperationValid &&
         this.decisionUriValid &&
-        this.codelistUriValid
+        this.codelistUriValid &&
+        this.graphForTargetsUriValid &&
+        this.propertyPathForTextUriValid
       );
     else return this.selectedJobOperationValid && this.urlValid;
   }
@@ -192,6 +200,8 @@ export default class OverviewJobsNewController extends Controller {
         jobAttributes = Object.assign(jobAttributes, {
           codelist: this.codelistUri,
           shapeForTargets: [shapeForTargets],
+          graphForTargets: this.graphForTargetsUri || undefined,
+          propertyPathForText: this.propertyPathForTextUri || undefined
         });
         scheduledJob = this.store.createRecord('annotation-job', jobAttributes);
       } else {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -229,7 +229,7 @@ export default class OverviewJobsNewController extends Controller {
           hasGraph: this.graphName,
         });
         await dataContainer.save();
-      } else {
+      } else if (!this.isCodelistMappingJob) {
         let sources = [this.url.trim()];
         if (this.selectedJobOperation.uri === this.jobCodelistMapping) {
           sources = [shapeForTargets.uri];

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -61,6 +61,8 @@ export default class OverviewJobsNewController extends Controller {
   @tracked graphForTargetsUriValid;
   @tracked propertyPathForTextUri = 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
+  @tracked confidenceTreshold = 0;
+  @tracked confidenceTresholdValid;
 
   @tracked loadingMunicipalities = false;
   @tracked municipalities = [];
@@ -147,6 +149,7 @@ export default class OverviewJobsNewController extends Controller {
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
+    this.confidenceTresholdValid = !isNaN(parseFloat(this.confidenceTreshold));
 
     if (!this.selectedJobOperation) return false;
     if (this.selectedJobOperation.uri === this.jobImport)
@@ -157,7 +160,8 @@ export default class OverviewJobsNewController extends Controller {
         this.decisionUriValid &&
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
-        this.propertyPathForTextUriValid
+        this.propertyPathForTextUriValid &&
+        this.confidenceTresholdValid
       );
     else return this.selectedJobOperationValid && this.urlValid;
   }
@@ -201,7 +205,8 @@ export default class OverviewJobsNewController extends Controller {
           codelist: this.codelistUri,
           shapeForTargets: [shapeForTargets],
           graphForTargets: this.graphForTargetsUri || undefined,
-          propertyPathForText: this.propertyPathForTextUri || 'https://data.europarl.europa.eu/def/epvoc#expressionContent'
+          propertyPathForText: this.propertyPathForTextUri || 'https://data.europarl.europa.eu/def/epvoc#expressionContent',
+          confidenceTreshold: this.confidenceTreshold || '0',
         });
         scheduledJob = this.store.createRecord('annotation-job', jobAttributes);
       } else {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -85,7 +85,7 @@ export default class OverviewJobsNewController extends Controller {
   get isJobWithMultipleEndpoints() {
     return this.selectedJobOperation?.uri === this.jobPdfScraping;
   }
-  
+
   get isCodelistMappingJob() {
     return (
       this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
@@ -158,7 +158,9 @@ export default class OverviewJobsNewController extends Controller {
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
-    this.confidenceThresholdValid = !isNaN(parseFloat(this.confidenceThreshold));
+    this.confidenceThresholdValid = !isNaN(
+      parseFloat(this.confidenceThreshold),
+    );
 
     if (!this.selectedJobOperation) return false;
     if (this.selectedJobOperation.uri === this.jobImport)

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -54,8 +54,8 @@ export default class OverviewJobsNewController extends Controller {
   @tracked selectedSecurityScheme;
   @tracked securityScheme = {};
   @tracked credentials = {};
-  @tracked decisionUri;
-  @tracked decisionUriValid;
+  @tracked decisionUris;
+  @tracked decisionUrisValid;
   @tracked codelistUri;
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
@@ -154,7 +154,7 @@ export default class OverviewJobsNewController extends Controller {
     else this.graphNameValid = false;
     if (this.vendor) this.vendorValid = true;
     else this.vendorValid = false;
-    this.decisionUriValid = true;
+    this.decisionUrisValid = true;
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
@@ -166,7 +166,7 @@ export default class OverviewJobsNewController extends Controller {
     else if (this.isCodelistMappingJob)
       return (
         this.selectedJobOperationValid &&
-        this.decisionUriValid &&
+        this.decisionUrisValid &&
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
@@ -197,9 +197,9 @@ export default class OverviewJobsNewController extends Controller {
 
       let shapeForTargets;
       if (this.isCodelistMappingJob) {
-        if (this.decisionUri) {
+        if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
-            targetNode: [this.decisionUri],
+            targetNode: this.decisionUris.split(/\n/).filter((x) => x),
           });
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -14,7 +14,8 @@ export default class OverviewJobsNewController extends Controller {
   jobHarvestAndImport = cts.JOB_OP_TYPE_HARVEST_AND_IMPORT;
   jobHarvestWorship = cts.JOB_OP_TYPE_HARVEST_WORSHIP;
   jobHarvestWorshipAndImport = cts.JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT;
-  jobCodelistMapping = cts.JOB_OP_TYPE_CODELIST_MAPPING;
+  jobCodelistMappingTraining = cts.JOB_OP_TYPE_CODELIST_MAPPING_TRAINING;
+  jobCodelistMappingAnnotating = cts.JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
@@ -59,7 +60,8 @@ export default class OverviewJobsNewController extends Controller {
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
   @tracked graphForTargetsUriValid;
-  @tracked propertyPathForTextUri = 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
+  @tracked propertyPathForTextUri =
+    'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
   @tracked confidenceTreshold = 0;
   @tracked confidenceTresholdValid;
@@ -82,6 +84,13 @@ export default class OverviewJobsNewController extends Controller {
 
   get isJobWithMultipleEndpoints() {
     return this.selectedJobOperation?.uri === this.jobPdfScraping;
+  }
+  
+  get isCodelistMappingJob() {
+    return (
+      this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
+      this.selectedJobOperation.uri === this.jobCodelistMappingAnnotating
+    );
   }
 
   @action
@@ -154,7 +163,7 @@ export default class OverviewJobsNewController extends Controller {
     if (!this.selectedJobOperation) return false;
     if (this.selectedJobOperation.uri === this.jobImport)
       return this.selectedJobOperationValid && this.graphNameValid;
-    else if (this.selectedJobOperation.uri === this.jobCodelistMapping)
+    else if (this.isCodelistMappingJob)
       return (
         this.selectedJobOperationValid &&
         this.decisionUriValid &&
@@ -187,16 +196,14 @@ export default class OverviewJobsNewController extends Controller {
       };
 
       let shapeForTargets;
-      if (this.selectedJobOperation.uri === this.jobCodelistMapping) {
+      if (this.isCodelistMappingJob) {
         if (this.decisionUri) {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetNode: [this.decisionUri],
           });
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {
-            targetClass: [
-              'http://data.europa.eu/eli/ontology#Expression',
-            ],
+            targetClass: ['http://data.europa.eu/eli/ontology#Expression'],
           });
         }
         await shapeForTargets.save();
@@ -204,7 +211,9 @@ export default class OverviewJobsNewController extends Controller {
           codelist: this.codelistUri,
           shapeForTargets: [shapeForTargets],
           graphForTargets: this.graphForTargetsUri || undefined,
-          propertyPathForText: this.propertyPathForTextUri || 'https://data.europarl.europa.eu/def/epvoc#expressionContent',
+          propertyPathForText:
+            this.propertyPathForTextUri ||
+            'https://data.europarl.europa.eu/def/epvoc#expressionContent',
           confidenceTreshold: this.confidenceTreshold || '0',
         });
         scheduledJob = this.store.createRecord('annotation-job', jobAttributes);

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -63,8 +63,8 @@ export default class OverviewJobsNewController extends Controller {
   @tracked propertyPathForTextUri =
     'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
-  @tracked confidenceTreshold = 0;
-  @tracked confidenceTresholdValid;
+  @tracked confidenceThreshold = 0;
+  @tracked confidenceThresholdValid;
 
   @tracked loadingMunicipalities = false;
   @tracked municipalities = [];
@@ -158,7 +158,7 @@ export default class OverviewJobsNewController extends Controller {
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
-    this.confidenceTresholdValid = !isNaN(parseFloat(this.confidenceTreshold));
+    this.confidenceThresholdValid = !isNaN(parseFloat(this.confidenceThreshold));
 
     if (!this.selectedJobOperation) return false;
     if (this.selectedJobOperation.uri === this.jobImport)
@@ -170,7 +170,7 @@ export default class OverviewJobsNewController extends Controller {
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
-        this.confidenceTresholdValid
+        this.confidenceThresholdValid
       );
     else return this.selectedJobOperationValid && this.urlValid;
   }
@@ -214,7 +214,7 @@ export default class OverviewJobsNewController extends Controller {
           propertyPathForText:
             this.propertyPathForTextUri ||
             'https://data.europarl.europa.eu/def/epvoc#expressionContent',
-          confidenceTreshold: this.confidenceTreshold || '0',
+          confidenceThreshold: this.confidenceThreshold || '0',
         });
         scheduledJob = this.store.createRecord('annotation-job', jobAttributes);
       } else {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -59,7 +59,7 @@ export default class OverviewJobsNewController extends Controller {
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
   @tracked graphForTargetsUriValid;
-  @tracked propertyPathForTextUri;
+  @tracked propertyPathForTextUri = 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
 
   @tracked loadingMunicipalities = false;
@@ -146,7 +146,7 @@ export default class OverviewJobsNewController extends Controller {
     this.decisionUriValid = true;
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
-    this.propertyPathForTextUriValid = true;
+    this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
 
     if (!this.selectedJobOperation) return false;
     if (this.selectedJobOperation.uri === this.jobImport)
@@ -201,7 +201,7 @@ export default class OverviewJobsNewController extends Controller {
           codelist: this.codelistUri,
           shapeForTargets: [shapeForTargets],
           graphForTargets: this.graphForTargetsUri || undefined,
-          propertyPathForText: this.propertyPathForTextUri || undefined
+          propertyPathForText: this.propertyPathForTextUri || 'https://data.europarl.europa.eu/def/epvoc#expressionContent'
         });
         scheduledJob = this.store.createRecord('annotation-job', jobAttributes);
       } else {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -15,7 +15,7 @@ export default class OverviewJobsNewController extends Controller {
   jobHarvestWorship = cts.JOB_OP_TYPE_HARVEST_WORSHIP;
   jobHarvestWorshipAndImport = cts.JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT;
   jobCodelistMappingTraining = cts.JOB_OP_TYPE_CODELIST_MAPPING_TRAINING;
-  jobCodelistMappingAnnotating = cts.JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING;
+  jobCodelistMappingEvaluation = cts.JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
@@ -89,7 +89,7 @@ export default class OverviewJobsNewController extends Controller {
   get isCodelistMappingJob() {
     return (
       this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
-      this.selectedJobOperation.uri === this.jobCodelistMappingAnnotating
+      this.selectedJobOperation.uri === this.jobCodelistMappingEvaluation
     );
   }
 
@@ -195,8 +195,8 @@ export default class OverviewJobsNewController extends Controller {
         vendor: this.vendor,
       };
 
-      let shapeForTargets;
       if (this.isCodelistMappingJob) {
+        let shapeForTargets;
         if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetNode: this.decisionUris.split(/\n/).filter((x) => x),
@@ -231,9 +231,6 @@ export default class OverviewJobsNewController extends Controller {
         await dataContainer.save();
       } else if (!this.isCodelistMappingJob) {
         let sources = [this.url.trim()];
-        if (this.selectedJobOperation.uri === this.jobCodelistMapping) {
-          sources = [shapeForTargets.uri];
-        }
         if (this.selectedJobOperation.uri === this.jobPdfScraping) {
           const newLinePattern = /\r?\n/;
           sources = this.url.split(newLinePattern).map((source) => {

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -93,16 +93,15 @@ export default class OverviewScheduledJobsNewController extends Controller {
     return timestamp;
   }
 
-<<<<<<< HEAD
   get isJobWithMultipleEndpoints() {
     return this.selectedJobOperation?.uri === this.jobPdfScraping;
-=======
+  }
+  
   get isCodelistMappingJob() {
     return (
       this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
       this.selectedJobOperation.uri === this.jobCodelistMappingAnnotating
     );
->>>>>>> 36e2433 (Split codelist mapping into two jobs.)
   }
 
   @action
@@ -179,6 +178,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
       const cronSchedule = this.store.createRecord('cron-schedule', {
         repeatFrequency: this.cronPattern,
       });
+      await cronSchedule.save();
 
       let jobName = 'scheduled-job';
       const jobAttributes = {
@@ -190,27 +190,6 @@ export default class OverviewScheduledJobsNewController extends Controller {
         schedule: cronSchedule,
         vendor: this.vendor,
       };
-
-      let sources = [this.url.trim()];
-      if (this.selectedJobOperation.uri === this.jobPdfScraping) {
-        const newLinePattern = /\r?\n/;
-        sources = this.url.split(newLinePattern).map((source) => {
-          if (!isValidUrl(source)) {
-            throw new Error(`Value: "${source}" is not a valid url.`);
-          }
-        });
-      }
-      const remoteDataObjects = sources.map((source) => {
-        return this.store.createRecord('remote-data-object', {
-          source: source,
-          status: undefined,
-          requestHeader:
-            'http://data.lblod.info/request-headers/accept/text/html',
-          created: this.currentTime,
-          modified: this.currentTime,
-          creator: this.creator,
-        });
-      });
 
       if (this.isCodelistMappingJob) {
         let shapeForTargets;
@@ -235,41 +214,66 @@ export default class OverviewScheduledJobsNewController extends Controller {
       }
 
       const scheduledJob = this.store.createRecord(jobName, jobAttributes);
+      await scheduledJob.save();
 
-      await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
-      const collection = this.store.createRecord('harvesting-collection', {
-        creator: this.creator,
-        //TODO: authentication configuration doesn't work currently for scheduled jobs. Because
-        // - Shallow copy of authtentication configuration (see DL-4896)
-        // - See timing issue comments, in controllers/jobs/new.js
-        authenticationConfiguration: this.selectedSecurityScheme
-          ? await createAuthenticationConfiguration(
-              this.selectedSecurityScheme,
-              this.securityScheme,
-              this.credentials,
-              this.store,
-            )
-          : null, // authenticationConfiguration is optional
-        remoteDataObjects: remoteDataObjects,
-      });
+      const inputContainers = [];
+      if (!this.isCodelistMappingJob) {
 
-      const dataContainer = this.store.createRecord('data-container', {
-        harvestingCollections: [collection],
-      });
+        let sources = [this.url.trim()];
+        if (this.selectedJobOperation.uri === this.jobPdfScraping) {
+          const newLinePattern = /\r?\n/;
+          sources = this.url.split(newLinePattern).map((source) => {
+            if (!isValidUrl(source)) {
+              throw new Error(`Value: "${source}" is not a valid url.`);
+            }
+          });
+        }
+        const remoteDataObjects = sources.map((source) => {
+          return this.store.createRecord('remote-data-object', {
+            source: source,
+            status: undefined,
+            requestHeader:
+              'http://data.lblod.info/request-headers/accept/text/html',
+            created: this.currentTime,
+            modified: this.currentTime,
+            creator: this.creator,
+          });
+        });
+
+        await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
+        const collection = this.store.createRecord('harvesting-collection', {
+          creator: this.creator,
+          //TODO: authentication configuration doesn't work currently for scheduled jobs. Because
+          // - Shallow copy of authtentication configuration (see DL-4896)
+          // - See timing issue comments, in controllers/jobs/new.js
+          authenticationConfiguration: this.selectedSecurityScheme
+            ? await createAuthenticationConfiguration(
+                this.selectedSecurityScheme,
+                this.securityScheme,
+                this.credentials,
+                this.store,
+              )
+            : null, // authenticationConfiguration is optional
+          remoteDataObjects: remoteDataObjects,
+        });
+        await collection.save();
+
+        const dataContainer = this.store.createRecord('data-container', {
+          harvestingCollections: [collection],
+        });
+        await dataContainer.save();
+
+        inputContainers.push(dataContainer);
+      }
 
       const scheduledTask = this.store.createRecord('scheduled-task', {
         created: this.currentTime,
         modified: this.currentTime,
         operation: this.harvestTaskOperation,
         index: '0',
-        inputContainers: [dataContainer],
+        inputContainers: inputContainers,
         scheduledJob: scheduledJob,
       });
-
-      await cronSchedule.save();
-      await collection.save();
-      await dataContainer.save();
-      await scheduledJob.save();
       await scheduledTask.save();
 
       this.toaster.success(

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -59,6 +59,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked graphForTargetsUriValid;
   @tracked propertyPathForTextUri = 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
+  @tracked confidenceTreshold = 0;
+  @tracked confidenceTresholdValid;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
@@ -136,6 +138,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = true;
+    this.confidenceTresholdValid = !isNaN(parseFloat(this.confidenceTreshold));
 
     const baseValid = (
       this.selectedJobOperationValid &&
@@ -148,7 +151,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
         this.decisionUriValid &&
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
-        this.propertyPathForTextUriValid;
+        this.propertyPathForTextUriValid &&
+        this.confidenceTresholdValid;
     else
       return baseValid && this.urlValid;
   }
@@ -217,6 +221,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         jobAttributes.codelist = this.codelistUri;
         jobAttributes.graphForTargets = this.graphForTargetsUri || undefined;
         jobAttributes.propertyPathForText = this.propertyPathForTextUri || 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
+        jobAttributes.confidenceTreshold = this.confidenceTreshold || '0';
         jobName = 'scheduled-annotation-job';
       }
 

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -15,7 +15,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobHarvestAndImport = cts.JOB_OP_TYPE_HARVEST_AND_IMPORT;
   jobHarvestWorship = cts.JOB_OP_TYPE_HARVEST_WORSHIP;
   jobHarvestWorshipAndImport = cts.JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT;
-  jobCodelistMapping = cts.JOB_OP_TYPE_CODELIST_MAPPING;
+  jobCodelistMappingTraining = cts.JOB_OP_TYPE_CODELIST_MAPPING_TRAINING;
+  jobCodelistMappingAnnotating = cts.JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
 
@@ -57,7 +58,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
   @tracked graphForTargetsUriValid;
-  @tracked propertyPathForTextUri = 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
+  @tracked propertyPathForTextUri =
+    'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
   @tracked confidenceTreshold = 0;
   @tracked confidenceTresholdValid;
@@ -91,8 +93,16 @@ export default class OverviewScheduledJobsNewController extends Controller {
     return timestamp;
   }
 
+<<<<<<< HEAD
   get isJobWithMultipleEndpoints() {
     return this.selectedJobOperation?.uri === this.jobPdfScraping;
+=======
+  get isCodelistMappingJob() {
+    return (
+      this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
+      this.selectedJobOperation.uri === this.jobCodelistMappingAnnotating
+    );
+>>>>>>> 36e2433 (Split codelist mapping into two jobs.)
   }
 
   @action
@@ -140,21 +150,21 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.propertyPathForTextUriValid = true;
     this.confidenceTresholdValid = !isNaN(parseFloat(this.confidenceTreshold));
 
-    const baseValid = (
+    const baseValid =
       this.selectedJobOperationValid &&
       this.titleValid &&
-      this.cronPatternValid
-    );
+      this.cronPatternValid;
 
-    if (this.selectedJobOperation.uri === this.jobCodelistMapping)
-      return baseValid &&
+    if (this.isCodelistMappingJob)
+      return (
+        baseValid &&
         this.decisionUriValid &&
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
-        this.confidenceTresholdValid;
-    else
-      return baseValid && this.urlValid;
+        this.confidenceTresholdValid
+      );
+    else return baseValid && this.urlValid;
   }
 
   @action
@@ -170,8 +180,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
         repeatFrequency: this.cronPattern,
       });
 
-    let jobName = 'scheduled-job';
-    const jobAttributes = {
+      let jobName = 'scheduled-job';
+      const jobAttributes = {
         creator: this.creator,
         created: this.currentTime,
         modified: this.currentTime,
@@ -202,7 +212,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         });
       });
 
-      if (this.selectedJobOperation.uri === this.jobCodelistMapping) {
+      if (this.isCodelistMappingJob) {
         let shapeForTargets;
         if (this.decisionUri) {
           shapeForTargets = this.store.createRecord('node-shape', {
@@ -210,16 +220,16 @@ export default class OverviewScheduledJobsNewController extends Controller {
           });
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {
-            targetClass: [
-              'http://data.europa.eu/eli/ontology#Expression',
-            ],
+            targetClass: ['http://data.europa.eu/eli/ontology#Expression'],
           });
         }
         await shapeForTargets.save();
         jobAttributes.shapeForTargets = [shapeForTargets];
         jobAttributes.codelist = this.codelistUri;
         jobAttributes.graphForTargets = this.graphForTargetsUri || undefined;
-        jobAttributes.propertyPathForText = this.propertyPathForTextUri || 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
+        jobAttributes.propertyPathForText =
+          this.propertyPathForTextUri ||
+          'https://data.europarl.europa.eu/def/epvoc#expressionContent';
         jobAttributes.confidenceTreshold = this.confidenceTreshold || '0';
         jobName = 'scheduled-annotation-job';
       }

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -57,7 +57,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
   @tracked graphForTargetsUriValid;
-  @tracked propertyPathForTextUri;
+  @tracked propertyPathForTextUri = 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
@@ -216,7 +216,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         jobAttributes.shapeForTargets = [shapeForTargets];
         jobAttributes.codelist = this.codelistUri;
         jobAttributes.graphForTargets = this.graphForTargetsUri || undefined;
-        jobAttributes.propertyPathForText = this.propertyPathForTextUri || undefined;
+        jobAttributes.propertyPathForText = this.propertyPathForTextUri || 'https://data.europarl.europa.eu/def/epvoc#expressionContent';
         jobName = 'scheduled-annotation-job';
       }
 

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -55,6 +55,10 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked decisionUriValid;
   @tracked codelistUri;
   @tracked codelistUriValid = true;
+  @tracked graphForTargetsUri;
+  @tracked graphForTargetsUriValid;
+  @tracked propertyPathForTextUri;
+  @tracked propertyPathForTextUriValid;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
@@ -130,6 +134,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.vendorValid = !!this.vendor;
     this.decisionUriValid = true;
     this.codelistUriValid = !!this.codelistUri;
+    this.graphForTargetsUriValid = true;
+    this.propertyPathForTextUriValid = true;
 
     const baseValid = (
       this.selectedJobOperationValid &&
@@ -140,7 +146,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
     if (this.selectedJobOperation.uri === this.jobCodelistMapping)
       return baseValid &&
         this.decisionUriValid &&
-        this.codelistUriValid;
+        this.codelistUriValid &&
+        this.graphForTargetsUriValid &&
+        this.propertyPathForTextUriValid;
     else
       return baseValid && this.urlValid;
   }
@@ -207,9 +215,11 @@ export default class OverviewScheduledJobsNewController extends Controller {
         await shapeForTargets.save();
         jobAttributes.shapeForTargets = [shapeForTargets];
         jobAttributes.codelist = this.codelistUri;
+        jobAttributes.graphForTargets = this.graphForTargetsUri || undefined;
+        jobAttributes.propertyPathForText = this.propertyPathForTextUri || undefined;
         jobName = 'scheduled-annotation-job';
       }
-      
+
       const scheduledJob = this.store.createRecord(jobName, jobAttributes);
 
       await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -15,6 +15,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobHarvestAndImport = cts.JOB_OP_TYPE_HARVEST_AND_IMPORT;
   jobHarvestWorship = cts.JOB_OP_TYPE_HARVEST_WORSHIP;
   jobHarvestWorshipAndImport = cts.JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT;
+  jobCodelistMapping = cts.JOB_OP_TYPE_CODELIST_MAPPING;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
 
@@ -50,6 +51,10 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked selectedSecurityScheme;
   @tracked securityScheme;
   @tracked credentials;
+  @tracked decisionUri;
+  @tracked decisionUriValid;
+  @tracked codelistUri;
+  @tracked codelistUriValid = true;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
@@ -99,7 +104,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   }
 
   @action
-  setJobOperation(selected) {
+  async setJobOperation(selected) {
     this.selectedJobOperation = selected;
     this.url =
       selected?.uri === this.jobHarvestOsloEli
@@ -123,12 +128,21 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.titleValid = !!this.title;
     this.cronPatternValid = this.isValidCronPattern;
     this.vendorValid = !!this.vendor;
-    return (
+    this.decisionUriValid = true;
+    this.codelistUriValid = !!this.codelistUri;
+
+    const baseValid = (
       this.selectedJobOperationValid &&
-      this.urlValid &&
       this.titleValid &&
       this.cronPatternValid
     );
+
+    if (this.selectedJobOperation.uri === this.jobCodelistMapping)
+      return baseValid &&
+        this.decisionUriValid &&
+        this.codelistUriValid;
+    else
+      return baseValid && this.urlValid;
   }
 
   @action
@@ -144,7 +158,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
         repeatFrequency: this.cronPattern,
       });
 
-      const scheduledJob = this.store.createRecord('scheduled-job', {
+    let jobName = 'scheduled-job';
+    const jobAttributes = {
         creator: this.creator,
         created: this.currentTime,
         modified: this.currentTime,
@@ -152,7 +167,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
         title: this.title,
         schedule: cronSchedule,
         vendor: this.vendor,
-      });
+      };
+
       let sources = [this.url.trim()];
       if (this.selectedJobOperation.uri === this.jobPdfScraping) {
         const newLinePattern = /\r?\n/;
@@ -173,6 +189,29 @@ export default class OverviewScheduledJobsNewController extends Controller {
           creator: this.creator,
         });
       });
+
+      if (this.selectedJobOperation.uri === this.jobCodelistMapping) {
+        let shapeForTargets;
+        if (this.decisionUri) {
+          shapeForTargets = this.store.createRecord('node-shape', {
+            targetNode: [this.decisionUri],
+          });
+        } else {
+          shapeForTargets = this.store.createRecord('node-shape', {
+            targetClass: [
+              // Alternative: 'http://data.vlaanderen.be/ns/besluit#Besluit',
+              'http://data.europa.eu/eli/ontology#LegalExpression',
+            ],
+          });
+        }
+        await shapeForTargets.save();
+        jobAttributes.shapeForTargets = [shapeForTargets];
+        jobAttributes.codelist = this.codelistUri;
+        jobName = 'scheduled-annotation-job';
+      }
+      
+      const scheduledJob = this.store.createRecord(jobName, jobAttributes);
+
       await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
       const collection = this.store.createRecord('harvesting-collection', {
         creator: this.creator,

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -61,8 +61,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked propertyPathForTextUri =
     'https://data.europarl.europa.eu/def/epvoc#expressionContent';
   @tracked propertyPathForTextUriValid;
-  @tracked confidenceTreshold = 0;
-  @tracked confidenceTresholdValid;
+  @tracked confidenceThreshold = 0;
+  @tracked confidenceThresholdValid;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
@@ -147,7 +147,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = true;
-    this.confidenceTresholdValid = !isNaN(parseFloat(this.confidenceTreshold));
+    this.confidenceThresholdValid = !isNaN(parseFloat(this.confidenceThreshold));
 
     const baseValid =
       this.selectedJobOperationValid &&
@@ -161,7 +161,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
-        this.confidenceTresholdValid
+        this.confidenceThresholdValid
       );
     else return baseValid && this.urlValid;
   }
@@ -209,7 +209,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         jobAttributes.propertyPathForText =
           this.propertyPathForTextUri ||
           'https://data.europarl.europa.eu/def/epvoc#expressionContent';
-        jobAttributes.confidenceTreshold = this.confidenceTreshold || '0';
+        jobAttributes.confidenceThreshold = this.confidenceThreshold || '0';
         jobName = 'scheduled-annotation-job';
       }
 

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -96,7 +96,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   get isJobWithMultipleEndpoints() {
     return this.selectedJobOperation?.uri === this.jobPdfScraping;
   }
-  
+
   get isCodelistMappingJob() {
     return (
       this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
@@ -147,7 +147,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = true;
-    this.confidenceThresholdValid = !isNaN(parseFloat(this.confidenceThreshold));
+    this.confidenceThresholdValid = !isNaN(
+      parseFloat(this.confidenceThreshold),
+    );
 
     const baseValid =
       this.selectedJobOperationValid &&
@@ -218,7 +220,6 @@ export default class OverviewScheduledJobsNewController extends Controller {
 
       const inputContainers = [];
       if (!this.isCodelistMappingJob) {
-
         let sources = [this.url.trim()];
         if (this.selectedJobOperation.uri === this.jobPdfScraping) {
           const newLinePattern = /\r?\n/;
@@ -240,7 +241,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
           });
         });
 
-        await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
+        await Promise.all(
+          remoteDataObjects.map(async (rdo) => await rdo.save()),
+        );
         const collection = this.store.createRecord('harvesting-collection', {
           creator: this.creator,
           //TODO: authentication configuration doesn't work currently for scheduled jobs. Because

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -211,8 +211,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetClass: [
-              // Alternative: 'http://data.vlaanderen.be/ns/besluit#Besluit',
-              'http://data.europa.eu/eli/ontology#LegalExpression',
+              'http://data.europa.eu/eli/ontology#Expression',
             ],
           });
         }

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -16,7 +16,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobHarvestWorship = cts.JOB_OP_TYPE_HARVEST_WORSHIP;
   jobHarvestWorshipAndImport = cts.JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT;
   jobCodelistMappingTraining = cts.JOB_OP_TYPE_CODELIST_MAPPING_TRAINING;
-  jobCodelistMappingAnnotating = cts.JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING;
+  jobCodelistMappingEvaluation = cts.JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
 
@@ -100,7 +100,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   get isCodelistMappingJob() {
     return (
       this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
-      this.selectedJobOperation.uri === this.jobCodelistMappingAnnotating
+      this.selectedJobOperation.uri === this.jobCodelistMappingEvaluation
     );
   }
 

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -52,8 +52,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked selectedSecurityScheme;
   @tracked securityScheme;
   @tracked credentials;
-  @tracked decisionUri;
-  @tracked decisionUriValid;
+  @tracked decisionUris;
+  @tracked decisionUrisValid;
   @tracked codelistUri;
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
@@ -144,7 +144,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.titleValid = !!this.title;
     this.cronPatternValid = this.isValidCronPattern;
     this.vendorValid = !!this.vendor;
-    this.decisionUriValid = true;
+    this.decisionUrisValid = true;
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = true;
@@ -158,7 +158,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
     if (this.isCodelistMappingJob)
       return (
         baseValid &&
-        this.decisionUriValid &&
+        this.decisionUrisValid &&
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
@@ -214,9 +214,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
 
       if (this.isCodelistMappingJob) {
         let shapeForTargets;
-        if (this.decisionUri) {
+        if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
-            targetNode: [this.decisionUri],
+            targetNode: this.decisionUris.split(/\n/).filter((x) => x),
           });
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {

--- a/app/models/annotation-job.js
+++ b/app/models/annotation-job.js
@@ -6,5 +6,5 @@ export default class AnnotationJobModel extends JobModel {
   @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
   @attr graphForTargets;
   @attr propertyPathForText;
-  @attr('number') confidenceTreshold;
+  @attr('number') confidenceThreshold;
 }

--- a/app/models/annotation-job.js
+++ b/app/models/annotation-job.js
@@ -6,4 +6,5 @@ export default class AnnotationJobModel extends JobModel {
   @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
   @attr graphForTargets;
   @attr propertyPathForText;
+  @attr('number') confidenceTreshold;
 }

--- a/app/models/annotation-job.js
+++ b/app/models/annotation-job.js
@@ -4,4 +4,6 @@ import JobModel from './job';
 export default class AnnotationJobModel extends JobModel {
   @attr codelist;
   @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
+  @attr graphForTargets;
+  @attr propertyPathForText;
 }

--- a/app/models/scheduled-annotation-job.js
+++ b/app/models/scheduled-annotation-job.js
@@ -3,5 +3,7 @@ import ScheduledJobModel from './scheduled-job';
 
 export default class AnnotationJobModel extends ScheduledJobModel {
   @attr codelist;
+  @attr graphForTargets;
+  @attr propertyPathForText;
   @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
 }

--- a/app/models/scheduled-annotation-job.js
+++ b/app/models/scheduled-annotation-job.js
@@ -5,6 +5,6 @@ export default class AnnotationJobModel extends ScheduledJobModel {
   @attr codelist;
   @attr graphForTargets;
   @attr propertyPathForText;
-  @attr('number') confidenceTreshold;
+  @attr('number') confidenceThreshold;
   @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
 }

--- a/app/models/scheduled-annotation-job.js
+++ b/app/models/scheduled-annotation-job.js
@@ -1,0 +1,7 @@
+import { attr, hasMany } from '@ember-data/model';
+import ScheduledJobModel from './scheduled-job';
+
+export default class AnnotationJobModel extends ScheduledJobModel {
+  @attr codelist;
+  @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
+}

--- a/app/models/scheduled-annotation-job.js
+++ b/app/models/scheduled-annotation-job.js
@@ -5,5 +5,6 @@ export default class AnnotationJobModel extends ScheduledJobModel {
   @attr codelist;
   @attr graphForTargets;
   @attr propertyPathForText;
+  @attr('number') confidenceTreshold;
   @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
 }

--- a/app/models/scheduled-job.js
+++ b/app/models/scheduled-job.js
@@ -11,9 +11,13 @@ export default class ScheduledJobModel extends Model {
   @attr operation;
   @attr vendor;
 
-  @hasMany('scheduled-task', { async: true, inverse: 'scheduledJob' })
+  @hasMany('scheduled-task', { async: true, inverse: 'scheduledJob', as: 'scheduled-job' })
   scheduledTasks;
   @belongsTo('cron-schedule', { async: true, inverse: null }) schedule;
+
+  // For codelist mapping tasks
+  @attr codelist;
+  @hasMany('node-shape', { async: true, inverse: null }) shapeForTargets;
 
   get isConsumerDeltaSyncJob() {
     return this.operation === cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;

--- a/app/models/scheduled-job.js
+++ b/app/models/scheduled-job.js
@@ -11,7 +11,11 @@ export default class ScheduledJobModel extends Model {
   @attr operation;
   @attr vendor;
 
-  @hasMany('scheduled-task', { async: true, inverse: 'scheduledJob', as: 'scheduled-job' })
+  @hasMany('scheduled-task', {
+    async: true,
+    inverse: 'scheduledJob',
+    as: 'scheduled-job',
+  })
   scheduledTasks;
   @belongsTo('cron-schedule', { async: true, inverse: null }) schedule;
 

--- a/app/models/scheduled-task.js
+++ b/app/models/scheduled-task.js
@@ -7,7 +7,7 @@ export default class ScheduledTaskModel extends Model {
   @attr operation;
   @attr index;
 
-  @belongsTo('scheduled-job', { async: true, inverse: 'scheduledTasks' })
+  @belongsTo('scheduled-job', { async: true, inverse: 'scheduledTasks', polymorphic: true })
   scheduledJob;
 
   @hasMany('task', { async: true, inverse: null }) parentTasks;

--- a/app/models/scheduled-task.js
+++ b/app/models/scheduled-task.js
@@ -7,7 +7,11 @@ export default class ScheduledTaskModel extends Model {
   @attr operation;
   @attr index;
 
-  @belongsTo('scheduled-job', { async: true, inverse: 'scheduledTasks', polymorphic: true })
+  @belongsTo('scheduled-job', {
+    async: true,
+    inverse: 'scheduledTasks',
+    polymorphic: true,
+  })
   scheduledJob;
 
   @hasMany('task', { async: true, inverse: null }) parentTasks;

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -96,6 +96,7 @@
                 id="property-path-for-text-uri"
                 @width="block"
                 value={{this.propertyPathForTextUri}}
+                placeholder="https://data.europarl.europa.eu/def/epvoc#expressionContent"
                 {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
               />
             </AuFormRow>

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -47,7 +47,7 @@
                 {{on "change" (fn this.setProperty "graphName")}}
               />
             </AuFormRow>
-          {{else if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingAnnotating))}}
+          {{else if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingEvaluation))}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="task-codelist-uri"

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -101,15 +101,15 @@
               />
             </AuFormRow>
           <AuFormRow @alignment="default">
-            <AuLabel for="confidence-treshold">
-              Confidence treshold
+            <AuLabel for="confidence-threshold">
+              Confidence threshold
             </AuLabel>
             <AuInput
-              id="confidence-treshold"
+              id="confidence-threshold"
               @width="block"
-              value={{this.confidenceTreshold}}
+              value={{this.confidenceThreshold}}
               placeholder="An integer number between 0 and 100"
-              {{on "change" (fn this.setProperty "confidenceTreshold")}}
+              {{on "change" (fn this.setProperty "confidenceThreshold")}}
             />
           </AuFormRow>
           {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -47,7 +47,7 @@
                 {{on "change" (fn this.setProperty "graphName")}}
               />
             </AuFormRow>
-          {{else if (eq this.selectedJobOperation.uri this.jobCodelistMapping)}}
+          {{else if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingAnnotating))}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="task-codelist-uri"

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -77,6 +77,28 @@
                 {{on "change" (fn this.setProperty "decisionUri")}}
               />
             </AuFormRow>
+            <AuFormRow @alignment="default">
+              <AuLabel for="graph-for-targets-uri">
+                Graph for targets
+              </AuLabel>
+              <AuInput
+                id="graph-for-targets-uri"
+                @width="block"
+                value={{this.graphForTargetsUri}}
+                {{on "change" (fn this.setProperty "graphForTargetsUri")}}
+              />
+            </AuFormRow>
+            <AuFormRow @alignment="default">
+              <AuLabel for="property-path-for-text-uri">
+                Property path for text
+              </AuLabel>
+              <AuInput
+                id="property-path-for-text-uri"
+                @width="block"
+                value={{this.propertyPathForTextUri}}
+                {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
+              />
+            </AuFormRow>
           {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decisions-published-by">

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -100,6 +100,18 @@
                 {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
               />
             </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel for="confidence-treshold">
+              Confidence treshold
+            </AuLabel>
+            <AuInput
+              id="confidence-treshold"
+              @width="block"
+              value={{this.confidenceTreshold}}
+              placeholder="An integer number between 0 and 100"
+              {{on "change" (fn this.setProperty "confidenceTreshold")}}
+            />
+          </AuFormRow>
           {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decisions-published-by">

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -79,7 +79,7 @@
             </AuFormRow>
             <AuFormRow @alignment="default">
               <AuLabel for="graph-for-targets-uri">
-                Graph for targets
+                Decisions graph
               </AuLabel>
               <AuInput
                 id="graph-for-targets-uri"
@@ -90,7 +90,7 @@
             </AuFormRow>
             <AuFormRow @alignment="default">
               <AuLabel for="property-path-for-text-uri">
-                Property path for text
+                Property for decision content
               </AuLabel>
               <AuInput
                 id="property-path-for-text-uri"

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -67,14 +67,14 @@
             </AuFormRow>
             <AuFormRow @alignment="default">
               <AuLabel for="task-decisions-uri">
-                Decision to map
+                Decisions to map
               </AuLabel>
-              <AuInput
+              <AuTextarea
                 id="task-decisions-uri"
                 @width="block"
-                value={{this.decisionUri}}
-                placeholder="Leave blank to apply to all decisions"
-                {{on "change" (fn this.setProperty "decisionUri")}}
+                value={{this.decisionUris}}
+                placeholder="Every line is a decision URI; leave blank to apply to all decisions"
+                {{on "change" (fn this.setProperty "decisionUris")}}
               />
             </AuFormRow>
             <AuFormRow @alignment="default">

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -69,12 +69,12 @@
             <AuLabel for="task-decisions-uri">
               Decision to map
             </AuLabel>
-            <AuInput
+            <AuTextarea
               id="task-decisions-uri"
               @width="block"
-              value={{this.decisionUri}}
-              placeholder="Leave blank to apply to all decisions"
-              {{on "change" (fn this.setProperty "decisionUri")}}
+              value={{this.decisionUris}}
+              placeholder="Every line is a decision URI; leave blank to apply to all decisions"
+              {{on "change" (fn this.setProperty "decisionUris")}}
             />
           </AuFormRow>
           <AuFormRow @alignment="default">

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -47,7 +47,7 @@
             {{on "change" (fn this.setProperty "title")}}
           />
         </AuFormRow>
-        {{#if (eq this.selectedJobOperation.uri this.jobCodelistMapping)}}
+        {{#if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingAnnotating))}}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-codelist-uri"

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -79,7 +79,7 @@
           </AuFormRow>
           <AuFormRow @alignment="default">
             <AuLabel for="graph-for-targets-uri">
-              Graph for targets
+              Decisions graph
             </AuLabel>
             <AuInput
               id="graph-for-targets-uri"
@@ -90,7 +90,7 @@
           </AuFormRow>
           <AuFormRow @alignment="default">
             <AuLabel for="property-path-for-text-uri">
-              Property path for text
+              Property for decision content
             </AuLabel>
             <AuInput
               id="property-path-for-text-uri"

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -47,7 +47,37 @@
             {{on "change" (fn this.setProperty "title")}}
           />
         </AuFormRow>
-        {{#if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
+        {{#if (eq this.selectedJobOperation.uri this.jobCodelistMapping)}}
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="task-codelist-uri"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.codelistUriValid}}
+              >
+              Codelist
+            </AuLabel>
+            <AuInput
+              id="task-codelist-uri"
+              @width="block"
+              value={{this.codelistUri}}
+              @error={{not this.codelistUriValid}}
+              {{on "change" (fn this.setProperty "codelistUri")}}
+            />
+          </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel for="task-decisions-uri">
+              Decision to map
+            </AuLabel>
+            <AuInput
+              id="task-decisions-uri"
+              @width="block"
+              value={{this.decisionUri}}
+              placeholder="Leave blank to apply to all decisions"
+              {{on "change" (fn this.setProperty "decisionUri")}}
+            />
+          </AuFormRow>
+        {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decisions-published-by">
                 Published by

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -100,6 +100,18 @@
               {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
             />
           </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel for="confidence-treshold">
+              Confidence treshold
+            </AuLabel>
+            <AuInput
+              id="confidence-treshold"
+              @width="block"
+              value={{this.confidenceTreshold}}
+              placeholder="An integer number between 0 and 100"
+              {{on "change" (fn this.setProperty "confidenceTreshold")}}
+            />
+          </AuFormRow>
         {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decisions-published-by">

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -96,6 +96,7 @@
               id="property-path-for-text-uri"
               @width="block"
               value={{this.propertyPathForTextUri}}
+              placeholder="https://data.europarl.europa.eu/def/epvoc#expressionContent"
               {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
             />
           </AuFormRow>

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -101,15 +101,15 @@
             />
           </AuFormRow>
           <AuFormRow @alignment="default">
-            <AuLabel for="confidence-treshold">
-              Confidence treshold
+            <AuLabel for="confidence-threshold">
+              Confidence threshold
             </AuLabel>
             <AuInput
-              id="confidence-treshold"
+              id="confidence-threshold"
               @width="block"
-              value={{this.confidenceTreshold}}
+              value={{this.confidenceThreshold}}
               placeholder="An integer number between 0 and 100"
-              {{on "change" (fn this.setProperty "confidenceTreshold")}}
+              {{on "change" (fn this.setProperty "confidenceThreshold")}}
             />
           </AuFormRow>
         {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -77,6 +77,28 @@
               {{on "change" (fn this.setProperty "decisionUri")}}
             />
           </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel for="graph-for-targets-uri">
+              Graph for targets
+            </AuLabel>
+            <AuInput
+              id="graph-for-targets-uri"
+              @width="block"
+              value={{this.graphForTargetsUri}}
+              {{on "change" (fn this.setProperty "graphForTargetsUri")}}
+            />
+          </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel for="property-path-for-text-uri">
+              Property path for text
+            </AuLabel>
+            <AuInput
+              id="property-path-for-text-uri"
+              @width="block"
+              value={{this.propertyPathForTextUri}}
+              {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
+            />
+          </AuFormRow>
         {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decisions-published-by">

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -47,7 +47,7 @@
             {{on "change" (fn this.setProperty "title")}}
           />
         </AuFormRow>
-        {{#if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingAnnotating))}}
+        {{#if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingEvaluation))}}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-codelist-uri"

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -36,8 +36,8 @@ export const JOB_OP_TYPE_ELI_ENTITY_LINKING_TEST =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/eli-entity-linking-test';
 export const JOB_OP_TYPE_CODELIST_MAPPING_TRAINING =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/codelist-matching/training';
-export const JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING =
-  'http://lblod.data.gift/id/jobs/concept/JobOperation/codelist-matching/annotate';
+export const JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION =
+  'http://lblod.data.gift/id/jobs/concept/JobOperation/codelist-matching/evaluation';
 
 export const CONSUMER_SYNC_MODES = {
   initial: 'http://mu.semte.ch/vocabularies/ext/decide-consumer/initial-sync',
@@ -84,7 +84,7 @@ JOB_OP_TYPES.set(
   'Codelist mapping (training)',
 );
 JOB_OP_TYPES.set(
-  JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING,
+  JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION,
   'Codelist mapping (annotating)',
 );
 export const JOB_OP_TYPE_CREATE = new Map();
@@ -146,8 +146,8 @@ if (['true', 'True', 'TRUE', true].includes(config.harvester.codelistMapping)) {
     'Codelist mapping (training)',
   );
   JOB_OP_TYPE_CREATE.set(
-    JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING,
-    'Codelist mapping (annotating)',
+    JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION,
+    'Codelist mapping (evaluation)',
   );
 }
 

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -34,8 +34,10 @@ export const JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/ner-and-nel-annotations';
 export const JOB_OP_TYPE_ELI_ENTITY_LINKING_TEST =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/eli-entity-linking-test';
-export const JOB_OP_TYPE_CODELIST_MAPPING =
-  'http://lblod.data.gift/id/jobs/concept/JobOperation/match-codelist';
+export const JOB_OP_TYPE_CODELIST_MAPPING_TRAINING =
+  'http://lblod.data.gift/id/jobs/concept/JobOperation/codelist-matching/training';
+export const JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING =
+  'http://lblod.data.gift/id/jobs/concept/JobOperation/codelist-matching/annotate';
 
 export const CONSUMER_SYNC_MODES = {
   initial: 'http://mu.semte.ch/vocabularies/ext/decide-consumer/initial-sync',
@@ -77,8 +79,14 @@ JOB_OP_TYPES.set(
   'Generate NER and NEL Annotations on ELI decisions',
 );
 JOB_OP_TYPES.set(JOB_OP_TYPE_ELI_ENTITY_LINKING_TEST, 'Entity Linking test');
-JOB_OP_TYPES.set(JOB_OP_TYPE_CODELIST_MAPPING, 'Codelist mapping');
-
+JOB_OP_TYPES.set(
+  JOB_OP_TYPE_CODELIST_MAPPING_TRAINING,
+  'Codelist mapping (training)',
+);
+JOB_OP_TYPES.set(
+  JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING,
+  'Codelist mapping (annotating)',
+);
 export const JOB_OP_TYPE_CREATE = new Map();
 
 if (
@@ -133,7 +141,14 @@ if (
   );
 }
 if (['true', 'True', 'TRUE', true].includes(config.harvester.codelistMapping)) {
-  JOB_OP_TYPE_CREATE.set(JOB_OP_TYPE_CODELIST_MAPPING, 'Codelist mapping');
+  JOB_OP_TYPE_CREATE.set(
+    JOB_OP_TYPE_CODELIST_MAPPING_TRAINING,
+    'Codelist mapping (training)',
+  );
+  JOB_OP_TYPE_CREATE.set(
+    JOB_OP_TYPE_CODELIST_MAPPING_ANNOTATING,
+    'Codelist mapping (annotating)',
+  );
 }
 
 export const JOB_OP_STATUS_SUCCESS =

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -85,7 +85,7 @@ JOB_OP_TYPES.set(
 );
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION,
-  'Codelist mapping (annotating)',
+  'Codelist mapping (evaluation)',
 );
 export const JOB_OP_TYPE_CREATE = new Map();
 


### PR DESCRIPTION
Reference: [LBRON-1230](https://binnenland.atlassian.net/browse/LBRON-1230)

This PR puts everything in place in the frontend for picking up codelist 
mapping jobs later.

- Adds codelist mapping operation to scheduled jobs (as opposed to just for standalone jobs).
- Splits codelist mapping operation into two jobs: one for training and one for annotating.
- Adds fields corresponding to `graphForTargets`, `propertyPathForText`, and `confidenceTreshold` to the frontend.
- Set `sh:targetClass` to `eli:Expression` in case no `sh:targetNode`s are provided (as opposed to `eli:LegalExpression` before).
- Allow the user to choose *multiple* (line-separated) target decisions on which to perform code mapping.
- Avoid performing code meant for harvesting tasks.

Backend PR: https://github.com/lblod/app-decide/pull/75