### PR TITLE
Feature/lbron 1145 decision list eli to ai

### DIFF
--- a/app/components/decision-selector-configuration.hbs
+++ b/app/components/decision-selector-configuration.hbs
@@ -1,0 +1,45 @@
+<AuFormRow @alignment="default">
+    <AuLabel for="task-decisions-uri">
+    Decisions to map
+    </AuLabel>
+    <AuTextarea
+    id="task-decisions-uri"
+    @width="block"
+    value={{@decisionUris}}
+    placeholder="Every line is a decision URI; leave blank to apply to all decisions"
+    {{on "change" (fn @setProperty "decisionUris")}}
+    />
+</AuFormRow>
+<AuFormRow @alignment="default">
+    <AuLabel for="graph-for-targets-uri">
+    Decisions graph
+    </AuLabel>
+    <AuInput
+    id="graph-for-targets-uri"
+    @width="block"
+    value={{@graphForTargetsUri}}
+    {{on "change" (fn @setProperty "graphForTargetsUri")}}
+    />
+</AuFormRow>
+<AuFormRow @alignment="default">
+    <AuLabel for="target-class-uri">
+    Target class for decision content
+    </AuLabel>
+    <AuInput
+    id="target-class-uri"
+    @width="block"
+    value={{@targetClassUri}}
+    {{on "change" (fn @setProperty "targetClassUri")}}
+    />
+</AuFormRow>
+<AuFormRow @alignment="default">
+    <AuLabel for="property-path-for-text-uri">
+    Property path for decision content
+    </AuLabel>
+    <AuTextarea
+    id="property-path-for-text-uri"
+    @width="block"
+    value={{@propertyPathForTextUri}}
+    {{on "change" (fn @setProperty "propertyPathForTextUri")}}
+    />
+</AuFormRow>

--- a/app/components/decision-selector-configuration.js
+++ b/app/components/decision-selector-configuration.js
@@ -1,0 +1,10 @@
+import Component from '@glimmer/component';
+import { service } from '@ember/service';
+
+export default class DecisionSelectorConfigurationComponent extends Component {
+  @service store;
+
+  constructor() {
+    super(...arguments);
+  }
+}

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -20,6 +20,7 @@ export default class OverviewJobsNewController extends Controller {
   jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
   jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
+  jobOparlToELI = cts.JOB_OP_TYPE_HARVESTING_OPARL;
 
   @tracked jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(
     ([key, value]) => {
@@ -28,6 +29,8 @@ export default class OverviewJobsNewController extends Controller {
   );
 
   creator = cts.JOB_CREATOR_SELF_SERVICE;
+
+  request_headers = cts.REQUEST_HEADERS;
 
   harvestTaskOperation =
     'http://lblod.data.gift/id/jobs/concept/TaskOperation/singleton-job';
@@ -260,7 +263,7 @@ export default class OverviewJobsNewController extends Controller {
           hasGraph: this.graphName,
         });
         await dataContainer.save();
-      } else if (this.isJobWithSingleEndpoint) {
+      } else if (this.isJobWithSingleUrl) {
         sources.push(this.url.trim());
       } else if (this.isJobWithMultipleEndpoints) {
         const newLinePattern = /\r?\n/;
@@ -272,15 +275,16 @@ export default class OverviewJobsNewController extends Controller {
           sources.push(source.trim());
         });
       }
-
+      console.log(sources);
       const remoteDataObjects = sources.map((source) => {
         return this.store.createRecord('remote-data-object', {
           source,
           // This is deliberate, the collector service will set the status and
           // therefore start the job later:
           status: undefined,
-          requestHeader:
-            'http://data.lblod.info/request-headers/accept/text/html',
+          requestHeader: this.request_headers.has(this.selectedJobOperation.uri)
+            ? this.request_headers.get(this.selectedJobOperation.uri)
+            : undefined,
           created: this.currentTime,
           modified: this.currentTime,
           creator: this.creator,

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -90,22 +90,22 @@ export default class OverviewJobsNewController extends Controller {
   }
 
   get isJobWithGraphName() {
-    return this.selectedJobOperation?.uri === this.jobImport ? true : false;
+    return this.selectedJobOperation?.uri === this.jobImport;
   }
 
-  get isJobWithSimpleUrl() {
-    return this.selectedJobOperation.uri !== this.jobImport &&
+  get isJobWithSingleUrl() {
+    return (
+      this.selectedJobOperation.uri !== this.jobImport &&
       !this.isJobWithDecisionSelector &&
       !this.isJobWithMultipleEndpoints
-      ? true
-      : false;
+    );
   }
 
   get isJobWithCodelist() {
-    return this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
+    return (
+      this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
       this.selectedJobOperation?.uri === this.jobCodelistMappingEvaluation
-      ? true
-      : false;
+    );
   }
 
   get isJobWithDecisionSelector() {
@@ -116,10 +116,10 @@ export default class OverviewJobsNewController extends Controller {
     );
   }
 
-  get isCodelistMappingJob() {
+  get isJobWithMunicipality() {
     return (
-      this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
-      this.selectedJobOperation.uri === this.jobCodelistMappingEvaluation
+      this.selectedJobOperation?.uri === this.jobHarvestPdfToELI ||
+      this.selectedJobOperation?.uri === this.jobPdfScraping
     );
   }
 
@@ -142,20 +142,8 @@ export default class OverviewJobsNewController extends Controller {
     this.selectedJobOperation = selected;
     this.url = undefined;
 
-    if (selected?.uri === cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI) {
-      this.loadingOrganizations = true;
-      this.municipalities = await this.store.query('organization', {
-        page: { size: 600 },
-        filter: {
-          classification:
-            'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
-        },
-        sort: ':no-case:pref-label',
-      });
-      this.loadingOrganizations = false;
-    } else {
-      this.municipalities = [];
-      this.selectedMunicipality = null;
+    if (this.isJobWithMunicipality) {
+      await this.loadMunicipalities();
     }
   }
 
@@ -193,28 +181,24 @@ export default class OverviewJobsNewController extends Controller {
       parseFloat(this.confidenceThreshold),
     );
 
-    if (!this.selectedJobOperation) return false;
-    if (this.selectedJobOperation.uri === this.jobImport)
-      return this.selectedJobOperationValid && this.graphNameValid;
-    else if (this.isCodelistMappingJob)
-      return (
-        this.selectedJobOperationValid &&
-        this.decisionUrisValid &&
-        this.codelistUriValid &&
-        this.graphForTargetsUriValid &&
-        this.propertyPathForTextUriValid &&
-        this.targetClassUriValid &&
-        this.confidenceThresholdValid
-      );
-    else if (this.selectedJobOperation.uri === this.jobEliToNERAndNEL) {
-      return (
-        this.selectedJobOperationValid &&
+    let isValid = this.selectedJobOperationValid;
+    // Once isValid is false, it stays false until the end
+    if (this.selectedJobOperation.uri === this.jobImport && isValid)
+      isValid = this.graphNameValid;
+    if (this.isJobWithCodelist && isValid) {
+      isValid = this.codelistUriValid;
+    }
+    if (this.isJobWithDecisionSelector && isValid) {
+      isValid =
         this.decisionUrisValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
-        this.targetClassUriValid
-      );
-    } else return this.selectedJobOperationValid && this.urlValid;
+        this.targetClassUriValid;
+    }
+    if (isValid) {
+      isValid = this.urlValid;
+    }
+    return isValid;
   }
 
   @action
@@ -223,11 +207,10 @@ export default class OverviewJobsNewController extends Controller {
   }
 
   createAndStartJob = task(async () => {
-    let scheduledJob;
-    const sources = [];
     try {
       if (!this.validateForm()) return;
 
+      let jobName = 'scheduled-job';
       let jobAttributes = {
         status: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
         created: this.currentTime,
@@ -237,6 +220,10 @@ export default class OverviewJobsNewController extends Controller {
         operation: this.selectedJobOperation.uri,
         vendor: this.vendor,
       };
+
+      if (this.isJobWithCodelist) {
+        jobAttributes.codelist = this.codelistUri;
+      }
 
       if (this.isJobWithDecisionSelector) {
         let shapeForTargets;
@@ -251,26 +238,26 @@ export default class OverviewJobsNewController extends Controller {
         }
         await shapeForTargets.save();
         jobAttributes = Object.assign(jobAttributes, {
-          codelist: this.codelistUri,
           shapeForTargets: [shapeForTargets],
           graphForTargets: this.graphForTargetsUri || undefined,
           propertyPathForText: this.propertyPathForTextUri,
           confidenceThreshold: this.confidenceThreshold || '0',
         });
-        scheduledJob = this.store.createRecord('annotation-job', jobAttributes);
-      } else {
-        scheduledJob = this.store.createRecord('job', jobAttributes);
+        jobName = 'annotation-job';
       }
+
+      const scheduledJob = this.store.createRecord(jobName, jobAttributes);
       await scheduledJob.save();
 
       const inputContainers = [];
+      const sources = [];
       let dataContainer, dataContainerWithMunicipality;
       if (this.selectedJobOperation.uri === this.jobImport) {
         dataContainer = this.store.createRecord('data-container', {
           hasGraph: this.graphName,
         });
         await dataContainer.save();
-      } else if (this.isJobWithSimpleUrl) {
+      } else if (this.isJobWithSingleEndpoint) {
         sources.push(this.url.trim());
       } else if (this.isJobWithMultipleEndpoints) {
         const newLinePattern = /\r?\n/;
@@ -355,4 +342,17 @@ export default class OverviewJobsNewController extends Controller {
       await scheduledJob.destroyRecord();
     }
   });
+
+  async loadMunicipalities() {
+    this.loadingOrganizations = true;
+    this.municipalities = await this.store.query('organization', {
+      page: { size: 600 },
+      filter: {
+        classification:
+          'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
+      },
+      sort: ':no-case:pref-label',
+    });
+    this.loadingOrganizations = false;
+  }
 }

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -56,7 +56,7 @@ export default class OverviewJobsNewController extends Controller {
   @tracked securityScheme = {};
   @tracked credentials = {};
   @tracked decisionUris;
-  @tracked decisionUrisValid;
+  @tracked decisionUrisValid = true;
   @tracked codelistUri;
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
@@ -260,7 +260,6 @@ export default class OverviewJobsNewController extends Controller {
       } else if (this.isJobWithSingleEndpoint) {
         sources.push(this.url.trim());
       } else if (this.isJobWithMultipleEndpoints) {
-        this.decisionUrisValid = true;
         const newLinePattern = /\r?\n/;
         this.url.split(newLinePattern).map((source) => {
           if (!isValidUrl(source)) {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -172,7 +172,6 @@ export default class OverviewJobsNewController extends Controller {
     else this.graphNameValid = false;
     if (this.vendor) this.vendorValid = true;
     else this.vendorValid = false;
-    this.decisionUrisValid = true;
     this.codelistUriValid = !!this.codelistUri;
     this.targetClassUriValid = !!this.targetClassUri;
     this.graphForTargetsUriValid = true;
@@ -195,7 +194,7 @@ export default class OverviewJobsNewController extends Controller {
         this.propertyPathForTextUriValid &&
         this.targetClassUriValid;
     }
-    if (isValid) {
+    if (this.isJobWithSingleUrl && isValid) {
       isValid = this.urlValid;
     }
     return isValid;
@@ -261,9 +260,11 @@ export default class OverviewJobsNewController extends Controller {
       } else if (this.isJobWithSingleEndpoint) {
         sources.push(this.url.trim());
       } else if (this.isJobWithMultipleEndpoints) {
+        this.decisionUrisValid = true;
         const newLinePattern = /\r?\n/;
         this.url.split(newLinePattern).map((source) => {
           if (!isValidUrl(source)) {
+            this.decisionUrisValid = false;
             throw new Error(`"${source}" is not a valid url.`);
           }
           sources.push(source.trim());

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -207,6 +207,7 @@ export default class OverviewJobsNewController extends Controller {
   }
 
   createAndStartJob = task(async () => {
+    let scheduledJob;
     try {
       if (!this.validateForm()) return;
 
@@ -246,7 +247,7 @@ export default class OverviewJobsNewController extends Controller {
         jobName = 'annotation-job';
       }
 
-      const scheduledJob = this.store.createRecord(jobName, jobAttributes);
+      scheduledJob = this.store.createRecord(jobName, jobAttributes);
       await scheduledJob.save();
 
       const inputContainers = [];

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -88,42 +88,29 @@ export default class OverviewJobsNewController extends Controller {
     return new Date();
   }
 
-  get isJobWithMultipleEndpoints() {
-    return this.selectedJobOperation?.uri === this.jobPdfScraping;
-  }
-
   get isJobWithGraphName() {
-    return this.selectedJobOperation?.uri === this.jobImport;
+    return cts.isJobWithGraphName(this.selectedJobOperation?.uri);
   }
-
   get isJobWithSingleUrl() {
-    return (
-      this.selectedJobOperation.uri !== this.jobImport &&
-      !this.isJobWithDecisionSelector &&
-      !this.isJobWithMultipleEndpoints
-    );
+    return cts.isJobWithSingleUrl(this.selectedJobOperation?.uri);
   }
-
-  get isJobWithCodelist() {
-    return (
-      this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
-      this.selectedJobOperation?.uri === this.jobCodelistMappingEvaluation
-    );
+  get isJobWithMultipleEndpoints() {
+    return cts.isJobWithMultipleEndpoints(this.selectedJobOperation?.uri);
   }
-
+  get isJobWithDecisionUris() {
+    return cts.isJobWithDecisionUris(this.selectedJobOperation?.uri);
+  }
   get isJobWithDecisionSelector() {
-    return (
-      this.selectedJobOperation?.uri === this.jobEliToNERAndNEL ||
-      this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
-      this.selectedJobOperation?.uri === this.jobCodelistMappingEvaluation
-    );
+    return cts.isJobWithDecisionSelector(this.selectedJobOperation?.uri);
   }
-
+  get isJobWithCodelist() {
+    return cts.isJobWithCodelist(this.selectedJobOperation?.uri);
+  }
   get isJobWithMunicipality() {
-    return (
-      this.selectedJobOperation?.uri === this.jobHarvestPdfToELI ||
-      this.selectedJobOperation?.uri === this.jobPdfScraping
-    );
+    return cts.isJobWithMunicipality(this.selectedJobOperation?.uri);
+  }
+  get isJobWithAuthentication() {
+    return cts.isJobWithAuthentication(this.selectedJobOperation?.uri);
   }
 
   @action
@@ -275,7 +262,6 @@ export default class OverviewJobsNewController extends Controller {
           sources.push(source.trim());
         });
       }
-      console.log(sources);
       const remoteDataObjects = sources.map((source) => {
         return this.store.createRecord('remote-data-object', {
           source,

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -210,7 +210,11 @@ export default class OverviewJobsNewController extends Controller {
     try {
       if (!this.validateForm()) return;
 
-      let jobName = 'scheduled-job';
+      let jobName = 'job';
+      if (this.isJobWithDecisionSelector) {
+        jobName = 'annotation-job';
+      }
+
       let jobAttributes = {
         status: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
         created: this.currentTime,
@@ -243,7 +247,6 @@ export default class OverviewJobsNewController extends Controller {
           propertyPathForText: this.propertyPathForTextUri,
           confidenceThreshold: this.confidenceThreshold || '0',
         });
-        jobName = 'annotation-job';
       }
 
       scheduledJob = this.store.createRecord(jobName, jobAttributes);

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -19,6 +19,7 @@ export default class OverviewJobsNewController extends Controller {
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
+  jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
 
   @tracked jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(
     ([key, value]) => {
@@ -61,8 +62,10 @@ export default class OverviewJobsNewController extends Controller {
   @tracked graphForTargetsUri;
   @tracked graphForTargetsUriValid;
   @tracked propertyPathForTextUri =
-    'https://data.europarl.europa.eu/def/epvoc#expressionContent';
+    '<http://data.europa.eu/eli/ontology#is_realized_by> / <https://data.europarl.europa.eu/def/epvoc#expressionContent>';
   @tracked propertyPathForTextUriValid;
+  @tracked targetClassUri = 'http://data.europa.eu/eli/ontology#Work';
+  @tracked targetClassUriValid;
   @tracked confidenceThreshold = 0;
   @tracked confidenceThresholdValid;
 
@@ -84,6 +87,33 @@ export default class OverviewJobsNewController extends Controller {
 
   get isJobWithMultipleEndpoints() {
     return this.selectedJobOperation?.uri === this.jobPdfScraping;
+  }
+
+  get isJobWithGraphName() {
+    return this.selectedJobOperation?.uri === this.jobImport ? true : false;
+  }
+
+  get isJobWithSimpleUrl() {
+    return this.selectedJobOperation.uri !== this.jobImport &&
+      !this.isJobWithDecisionSelector &&
+      !this.isJobWithMultipleEndpoints
+      ? true
+      : false;
+  }
+
+  get isJobWithCodelist() {
+    return this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
+      this.selectedJobOperation?.uri === this.jobCodelistMappingEvaluation
+      ? true
+      : false;
+  }
+
+  get isJobWithDecisionSelector() {
+    return (
+      this.selectedJobOperation?.uri === this.jobEliToNERAndNEL ||
+      this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
+      this.selectedJobOperation?.uri === this.jobCodelistMappingEvaluation
+    );
   }
 
   get isCodelistMappingJob() {
@@ -156,6 +186,7 @@ export default class OverviewJobsNewController extends Controller {
     else this.vendorValid = false;
     this.decisionUrisValid = true;
     this.codelistUriValid = !!this.codelistUri;
+    this.targetClassUriValid = !!this.targetClassUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
     this.confidenceThresholdValid = !isNaN(
@@ -172,9 +203,18 @@ export default class OverviewJobsNewController extends Controller {
         this.codelistUriValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
+        this.targetClassUriValid &&
         this.confidenceThresholdValid
       );
-    else return this.selectedJobOperationValid && this.urlValid;
+    else if (this.selectedJobOperation.uri === this.jobEliToNERAndNEL) {
+      return (
+        this.selectedJobOperationValid &&
+        this.decisionUrisValid &&
+        this.graphForTargetsUriValid &&
+        this.propertyPathForTextUriValid &&
+        this.targetClassUriValid
+      );
+    } else return this.selectedJobOperationValid && this.urlValid;
   }
 
   @action
@@ -184,6 +224,7 @@ export default class OverviewJobsNewController extends Controller {
 
   createAndStartJob = task(async () => {
     let scheduledJob;
+    const sources = [];
     try {
       if (!this.validateForm()) return;
 
@@ -197,7 +238,7 @@ export default class OverviewJobsNewController extends Controller {
         vendor: this.vendor,
       };
 
-      if (this.isCodelistMappingJob) {
+      if (this.isJobWithDecisionSelector) {
         let shapeForTargets;
         if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
@@ -205,7 +246,7 @@ export default class OverviewJobsNewController extends Controller {
           });
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {
-            targetClass: ['http://data.europa.eu/eli/ontology#Expression'],
+            targetClass: [this.targetClassUri.trim()],
           });
         }
         await shapeForTargets.save();
@@ -213,9 +254,7 @@ export default class OverviewJobsNewController extends Controller {
           codelist: this.codelistUri,
           shapeForTargets: [shapeForTargets],
           graphForTargets: this.graphForTargetsUri || undefined,
-          propertyPathForText:
-            this.propertyPathForTextUri ||
-            'https://data.europarl.europa.eu/def/epvoc#expressionContent',
+          propertyPathForText: this.propertyPathForTextUri,
           confidenceThreshold: this.confidenceThreshold || '0',
         });
         scheduledJob = this.store.createRecord('annotation-job', jobAttributes);
@@ -231,64 +270,62 @@ export default class OverviewJobsNewController extends Controller {
           hasGraph: this.graphName,
         });
         await dataContainer.save();
-      } else if (!this.isCodelistMappingJob) {
-        let sources = [this.url.trim()];
-        if (this.selectedJobOperation.uri === this.jobPdfScraping) {
-          const newLinePattern = /\r?\n/;
-          sources = this.url.split(newLinePattern).map((source) => {
-            if (!isValidUrl(source)) {
-              throw new Error(`"${source}" is not a valid url.`);
-            }
-          });
-        }
-
-        const remoteDataObjects = sources.map((source) => {
-          return this.store.createRecord('remote-data-object', {
-            source,
-            // This is deliberate, the collector service will set the status and
-            // therefore start the job later:
-            status: undefined,
-            requestHeader:
-              'http://data.lblod.info/request-headers/accept/text/html',
-            created: this.currentTime,
-            modified: this.currentTime,
-            creator: this.creator,
-          });
+      } else if (this.isJobWithSimpleUrl) {
+        sources.push(this.url.trim());
+      } else if (this.isJobWithMultipleEndpoints) {
+        const newLinePattern = /\r?\n/;
+        this.url.split(newLinePattern).map((source) => {
+          if (!isValidUrl(source)) {
+            throw new Error(`"${source}" is not a valid url.`);
+          }
+          sources.push(source.trim());
         });
-        await Promise.all(
-          remoteDataObjects.map(async (rdo) => await rdo.save()),
-        );
-        const collection = this.store.createRecord('harvesting-collection', {
+      }
+
+      const remoteDataObjects = sources.map((source) => {
+        return this.store.createRecord('remote-data-object', {
+          source,
+          // This is deliberate, the collector service will set the status and
+          // therefore start the job later:
+          status: undefined,
+          requestHeader:
+            'http://data.lblod.info/request-headers/accept/text/html',
+          created: this.currentTime,
+          modified: this.currentTime,
           creator: this.creator,
-          authenticationConfiguration: this.selectedSecurityScheme
-            ? await createAuthenticationConfiguration(
-                this.selectedSecurityScheme,
-                this.securityScheme,
-                this.credentials,
-                this.store,
-              )
-            : null, // authenticationConfiguration is optional
-          remoteDataObjects: remoteDataObjects,
         });
-        await collection.save();
+      });
+      await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
+      const collection = this.store.createRecord('harvesting-collection', {
+        creator: this.creator,
+        authenticationConfiguration: this.selectedSecurityScheme
+          ? await createAuthenticationConfiguration(
+              this.selectedSecurityScheme,
+              this.securityScheme,
+              this.credentials,
+              this.store,
+            )
+          : null, // authenticationConfiguration is optional
+        remoteDataObjects: remoteDataObjects,
+      });
+      await collection.save();
 
-        dataContainer = this.store.createRecord('data-container', {
-          harvestingCollections: [collection],
-        });
-        await dataContainer.save();
-        inputContainers.push(dataContainer);
+      dataContainer = this.store.createRecord('data-container', {
+        harvestingCollections: [collection],
+      });
+      await dataContainer.save();
+      inputContainers.push(dataContainer);
 
-        if (this.selectedJobOperation.uri === this.jobHarvestPdfToELI) {
-          dataContainerWithMunicipality = this.store.createRecord(
-            'data-container',
-            {
-              hasResource: [this.selectedMunicipality.uri],
-            },
-          );
+      if (this.selectedJobOperation.uri === this.jobHarvestPdfToELI) {
+        dataContainerWithMunicipality = this.store.createRecord(
+          'data-container',
+          {
+            hasResource: [this.selectedMunicipality.uri],
+          },
+        );
 
-          await dataContainerWithMunicipality.save();
-          inputContainers.push(dataContainerWithMunicipality);
-        }
+        await dataContainerWithMunicipality.save();
+        inputContainers.push(dataContainerWithMunicipality);
       }
 
       const task = this.store.createRecord('task', {

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -59,7 +59,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked securityScheme;
   @tracked credentials;
   @tracked decisionUris;
-  @tracked decisionUrisValid;
+  @tracked decisionUrisValid = true;
   @tracked codelistUri;
   @tracked codelistUriValid = true;
   @tracked graphForTargetsUri;
@@ -266,7 +266,6 @@ export default class OverviewScheduledJobsNewController extends Controller {
       if (this.isJobWithSingleEndpoint) {
         sources.push(this.url.trim());
       } else if (this.isJobWithMultipleEndpoints) {
-        this.decisionUrisValid = true;
         const newLinePattern = /\r?\n/;
         this.url.split(newLinePattern).map((source) => {
           if (!isValidUrl(source)) {

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -18,11 +18,17 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobCodelistMappingTraining = cts.JOB_OP_TYPE_CODELIST_MAPPING_TRAINING;
   jobCodelistMappingEvaluation = cts.JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
+  jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
+  jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
 
-  jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(([key, value]) => {
-    return { label: value, uri: key };
-  });
+  jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE)
+    .filter(([key]) => {
+      return key !== this.jobHarvestPdfToELI; // Exclude the PDF to ELI job operation as this is supposed to be a one-time job
+    })
+    .map(([key, value]) => {
+      return { label: value, uri: key };
+    });
 
   creator = cts.JOB_CREATOR_SELF_SERVICE;
 
@@ -59,10 +65,16 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked graphForTargetsUri;
   @tracked graphForTargetsUriValid;
   @tracked propertyPathForTextUri =
-    'https://data.europarl.europa.eu/def/epvoc#expressionContent';
+    '<http://data.europa.eu/eli/ontology#is_realized_by> / <https://data.europarl.europa.eu/def/epvoc#expressionContent>';
   @tracked propertyPathForTextUriValid;
+  @tracked targetClassUri = 'http://data.europa.eu/eli/ontology#Work';
+  @tracked targetClassUriValid;
   @tracked confidenceThreshold = 0;
   @tracked confidenceThresholdValid;
+
+  @tracked loadingMunicipalities = false;
+  @tracked municipalities = [];
+  @tracked selectedMunicipality;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
@@ -93,14 +105,33 @@ export default class OverviewScheduledJobsNewController extends Controller {
     return timestamp;
   }
 
+  get isJobWithSingleUrl() {
+    return !this.isJobWithDecisionSelector && !this.isJobWithMultipleEndpoints;
+  }
+
   get isJobWithMultipleEndpoints() {
     return this.selectedJobOperation?.uri === this.jobPdfScraping;
   }
 
-  get isCodelistMappingJob() {
+  get isJobWithCodelist() {
     return (
       this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
       this.selectedJobOperation.uri === this.jobCodelistMappingEvaluation
+    );
+  }
+
+  get isJobWithDecisionSelector() {
+    return (
+      this.selectedJobOperation?.uri === this.jobEliToNERAndNEL ||
+      this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
+      this.selectedJobOperation?.uri === this.jobCodelistMappingEvaluation
+    );
+  }
+
+  get isJobWithMunicipality() {
+    return (
+      this.selectedJobOperation?.uri === this.jobHarvestPdfToELI ||
+      this.selectedJobOperation?.uri === this.jobPdfScraping
     );
   }
 
@@ -125,6 +156,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
       selected?.uri === this.jobHarvestOsloEli
         ? this.deltaConsumerSyncModeUri
         : undefined;
+    if (this.isJobWithMunicipality) {
+      await this.loadMunicipalities();
+    }
   }
 
   @action
@@ -135,6 +169,11 @@ export default class OverviewScheduledJobsNewController extends Controller {
 
   @action
   noop() {}
+
+  @action
+  changeSelectedMunicipality(org) {
+    this.selectedMunicipality = org;
+  }
 
   @action
   validateForm() {
@@ -151,21 +190,25 @@ export default class OverviewScheduledJobsNewController extends Controller {
       parseFloat(this.confidenceThreshold),
     );
 
-    const baseValid =
+    // Once isValid is false, it stays false until the end
+    let isValid =
       this.selectedJobOperationValid &&
       this.titleValid &&
       this.cronPatternValid;
-
-    if (this.isCodelistMappingJob)
-      return (
-        baseValid &&
+    if (this.isJobWithCodelist && isValid) {
+      isValid = this.codelistUriValid;
+    }
+    if (this.isJobWithDecisionSelector && isValid) {
+      isValid =
         this.decisionUrisValid &&
-        this.codelistUriValid &&
         this.graphForTargetsUriValid &&
         this.propertyPathForTextUriValid &&
-        this.confidenceThresholdValid
-      );
-    else return baseValid && this.urlValid;
+        this.targetClassUriValid;
+    }
+    if (isValid) {
+      isValid = this.urlValid;
+    }
+    return isValid;
   }
 
   @action
@@ -183,7 +226,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
       await cronSchedule.save();
 
       let jobName = 'scheduled-job';
-      const jobAttributes = {
+      let jobAttributes = {
         creator: this.creator,
         created: this.currentTime,
         modified: this.currentTime,
@@ -193,7 +236,10 @@ export default class OverviewScheduledJobsNewController extends Controller {
         vendor: this.vendor,
       };
 
-      if (this.isCodelistMappingJob) {
+      if (this.isJobWithCodelist) {
+        jobAttributes.codelist = this.codelistUri;
+      }
+      if (this.isJobWithDecisionSelector) {
         let shapeForTargets;
         if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
@@ -201,17 +247,15 @@ export default class OverviewScheduledJobsNewController extends Controller {
           });
         } else {
           shapeForTargets = this.store.createRecord('node-shape', {
-            targetClass: ['http://data.europa.eu/eli/ontology#Expression'],
+            targetClass: [this.targetClassUri.trim()],
           });
         }
-        await shapeForTargets.save();
-        jobAttributes.shapeForTargets = [shapeForTargets];
-        jobAttributes.codelist = this.codelistUri;
-        jobAttributes.graphForTargets = this.graphForTargetsUri || undefined;
-        jobAttributes.propertyPathForText =
-          this.propertyPathForTextUri ||
-          'https://data.europarl.europa.eu/def/epvoc#expressionContent';
-        jobAttributes.confidenceThreshold = this.confidenceThreshold || '0';
+        jobAttributes = Object.assign(jobAttributes, {
+          shapeForTargets: [shapeForTargets],
+          graphForTargets: this.graphForTargetsUri || undefined,
+          propertyPathForText: this.propertyPathForTextUri,
+          confidenceThreshold: this.confidenceThreshold || '0',
+        });
         jobName = 'scheduled-annotation-job';
       }
 
@@ -219,55 +263,54 @@ export default class OverviewScheduledJobsNewController extends Controller {
       await scheduledJob.save();
 
       const inputContainers = [];
-      if (!this.isCodelistMappingJob) {
-        let sources = [this.url.trim()];
-        if (this.selectedJobOperation.uri === this.jobPdfScraping) {
-          const newLinePattern = /\r?\n/;
-          sources = this.url.split(newLinePattern).map((source) => {
-            if (!isValidUrl(source)) {
-              throw new Error(`Value: "${source}" is not a valid url.`);
-            }
-          });
-        }
-        const remoteDataObjects = sources.map((source) => {
-          return this.store.createRecord('remote-data-object', {
-            source: source,
-            status: undefined,
-            requestHeader:
-              'http://data.lblod.info/request-headers/accept/text/html',
-            created: this.currentTime,
-            modified: this.currentTime,
-            creator: this.creator,
-          });
+      const sources = [];
+      if (this.isJobWithSingleEndpoint) {
+        sources.push(this.url.trim());
+      } else if (this.isJobWithMultipleEndpoints) {
+        const newLinePattern = /\r?\n/;
+        this.url.split(newLinePattern).map((source) => {
+          if (!isValidUrl(source)) {
+            throw new Error(`"${source}" is not a valid url.`);
+          }
+          sources.push(source.trim());
         });
-
-        await Promise.all(
-          remoteDataObjects.map(async (rdo) => await rdo.save()),
-        );
-        const collection = this.store.createRecord('harvesting-collection', {
-          creator: this.creator,
-          //TODO: authentication configuration doesn't work currently for scheduled jobs. Because
-          // - Shallow copy of authtentication configuration (see DL-4896)
-          // - See timing issue comments, in controllers/jobs/new.js
-          authenticationConfiguration: this.selectedSecurityScheme
-            ? await createAuthenticationConfiguration(
-                this.selectedSecurityScheme,
-                this.securityScheme,
-                this.credentials,
-                this.store,
-              )
-            : null, // authenticationConfiguration is optional
-          remoteDataObjects: remoteDataObjects,
-        });
-        await collection.save();
-
-        const dataContainer = this.store.createRecord('data-container', {
-          harvestingCollections: [collection],
-        });
-        await dataContainer.save();
-
-        inputContainers.push(dataContainer);
       }
+      const remoteDataObjects = sources.map((source) => {
+        return this.store.createRecord('remote-data-object', {
+          source: source,
+          status: undefined,
+          requestHeader:
+            'http://data.lblod.info/request-headers/accept/text/html',
+          created: this.currentTime,
+          modified: this.currentTime,
+          creator: this.creator,
+        });
+      });
+
+      await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
+      const collection = this.store.createRecord('harvesting-collection', {
+        creator: this.creator,
+        //TODO: authentication configuration doesn't work currently for scheduled jobs. Because
+        // - Shallow copy of authtentication configuration (see DL-4896)
+        // - See timing issue comments, in controllers/jobs/new.js
+        authenticationConfiguration: this.selectedSecurityScheme
+          ? await createAuthenticationConfiguration(
+              this.selectedSecurityScheme,
+              this.securityScheme,
+              this.credentials,
+              this.store,
+            )
+          : null, // authenticationConfiguration is optional
+        remoteDataObjects: remoteDataObjects,
+      });
+      await collection.save();
+
+      const dataContainer = this.store.createRecord('data-container', {
+        harvestingCollections: [collection],
+      });
+      await dataContainer.save();
+
+      inputContainers.push(dataContainer);
 
       const scheduledTask = this.store.createRecord('scheduled-task', {
         created: this.currentTime,
@@ -293,4 +336,18 @@ export default class OverviewScheduledJobsNewController extends Controller {
       );
     }
   });
+
+  async loadMunicipalities() {
+    console.log('Loading municipalities...');
+    this.loadingOrganizations = true;
+    this.municipalities = await this.store.query('organization', {
+      page: { size: 600 },
+      filter: {
+        classification:
+          'http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001',
+      },
+      sort: ':no-case:pref-label',
+    });
+    this.loadingOrganizations = false;
+  }
 }

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -106,34 +106,29 @@ export default class OverviewScheduledJobsNewController extends Controller {
     return timestamp;
   }
 
+  get isJobWithGraphName() {
+    return cts.isJobWithGraphName(this.selectedJobOperation?.uri);
+  }
   get isJobWithSingleUrl() {
-    return !this.isJobWithDecisionSelector && !this.isJobWithMultipleEndpoints;
+    return cts.isJobWithSingleUrl(this.selectedJobOperation?.uri);
   }
-
   get isJobWithMultipleEndpoints() {
-    return this.selectedJobOperation?.uri === this.jobPdfScraping;
+    return cts.isJobWithMultipleEndpoints(this.selectedJobOperation?.uri);
   }
-
-  get isJobWithCodelist() {
-    return (
-      this.selectedJobOperation.uri === this.jobCodelistMappingTraining ||
-      this.selectedJobOperation.uri === this.jobCodelistMappingEvaluation
-    );
+  get isJobWithDecisionUris() {
+    return cts.isJobWithDecisionUris(this.selectedJobOperation?.uri);
   }
-
   get isJobWithDecisionSelector() {
-    return (
-      this.selectedJobOperation?.uri === this.jobEliToNERAndNEL ||
-      this.selectedJobOperation?.uri === this.jobCodelistMappingTraining ||
-      this.selectedJobOperation?.uri === this.jobCodelistMappingEvaluation
-    );
+    return cts.isJobWithDecisionSelector(this.selectedJobOperation?.uri);
   }
-
+  get isJobWithCodelist() {
+    return cts.isJobWithCodelist(this.selectedJobOperation?.uri);
+  }
   get isJobWithMunicipality() {
-    return (
-      this.selectedJobOperation?.uri === this.jobHarvestPdfToELI ||
-      this.selectedJobOperation?.uri === this.jobPdfScraping
-    );
+    return cts.isJobWithMunicipality(this.selectedJobOperation?.uri);
+  }
+  get isJobWithAuthentication() {
+    return cts.isJobWithAuthentication(this.selectedJobOperation?.uri);
   }
 
   @action

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -225,6 +225,10 @@ export default class OverviewScheduledJobsNewController extends Controller {
       await cronSchedule.save();
 
       let jobName = 'scheduled-job';
+      if (this.isJobWithDecisionSelector) {
+        jobName = 'scheduled-annotation-job';
+      }
+
       let jobAttributes = {
         creator: this.creator,
         created: this.currentTime,
@@ -255,7 +259,6 @@ export default class OverviewScheduledJobsNewController extends Controller {
           propertyPathForText: this.propertyPathForTextUri,
           confidenceThreshold: this.confidenceThreshold || '0',
         });
-        jobName = 'scheduled-annotation-job';
       }
 
       const scheduledJob = this.store.createRecord(jobName, jobAttributes);

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -182,7 +182,6 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.titleValid = !!this.title;
     this.cronPatternValid = this.isValidCronPattern;
     this.vendorValid = !!this.vendor;
-    this.decisionUrisValid = true;
     this.codelistUriValid = !!this.codelistUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = true;
@@ -205,7 +204,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         this.propertyPathForTextUriValid &&
         this.targetClassUriValid;
     }
-    if (isValid) {
+    if (this.isJobWithSingleUrl && isValid) {
       isValid = this.urlValid;
     }
     return isValid;
@@ -267,9 +266,11 @@ export default class OverviewScheduledJobsNewController extends Controller {
       if (this.isJobWithSingleEndpoint) {
         sources.push(this.url.trim());
       } else if (this.isJobWithMultipleEndpoints) {
+        this.decisionUrisValid = true;
         const newLinePattern = /\r?\n/;
         this.url.split(newLinePattern).map((source) => {
           if (!isValidUrl(source)) {
+            this.decisionUrisValid = false;
             throw new Error(`"${source}" is not a valid url.`);
           }
           sources.push(source.trim());

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -21,6 +21,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
   jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
+  jobOparlToELI = cts.JOB_OP_TYPE_HARVESTING_OPARL;
 
   jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE)
     .filter(([key]) => {
@@ -266,7 +267,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
 
       const inputContainers = [];
       const sources = [];
-      if (this.isJobWithSingleEndpoint) {
+      if (this.isJobWithSingleUrl) {
         sources.push(this.url.trim());
       } else if (this.isJobWithMultipleEndpoints) {
         const newLinePattern = /\r?\n/;

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -179,6 +179,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.cronPatternValid = this.isValidCronPattern;
     this.vendorValid = !!this.vendor;
     this.codelistUriValid = !!this.codelistUri;
+    this.targetClassUriValid = !!this.targetClassUri;
     this.graphForTargetsUriValid = true;
     this.propertyPathForTextUriValid = true;
     this.confidenceThresholdValid = !isNaN(

--- a/app/routes/overview/jobs/new.js
+++ b/app/routes/overview/jobs/new.js
@@ -5,6 +5,8 @@ export default class OverviewJobsNewRoute extends Route {
     super.setupController(...arguments);
     controller.set('selectedJobOperation', null);
     controller.set('selectedJobOperationValid', true);
+    controller.set('selectedMunicipality', null);
+    controller.set('codelistUri', null);
     controller.set('url', null);
     controller.set('urlValid', true);
     controller.set('comment', null);

--- a/app/routes/overview/scheduled-jobs/new.js
+++ b/app/routes/overview/scheduled-jobs/new.js
@@ -9,6 +9,8 @@ export default class OverviewScheduledJobsNewRoute extends Route {
     controller.set('urlValid', true);
     controller.set('selectedJobOperation', null);
     controller.set('selectedJobOperationValid', true);
+    controller.set('selectedMunicipality', null);
+    controller.set('codelistUri', null);
     controller.set('cronPattern', '*/5 * * * *');
     controller.set('cronPatternValid', true);
     controller.set('vendor', null);

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -30,7 +30,7 @@
         </PowerSelect>
       </AuFormRow>
       {{#if this.selectedJobOperation.uri}}
-          {{#if (eq this.selectedJobOperation.uri this.jobImport)}}
+          {{#if this.isJobWithGraphName}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="graph-name"
@@ -47,7 +47,9 @@
                 {{on "change" (fn this.setProperty "graphName")}}
               />
             </AuFormRow>
-          {{else if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingEvaluation))}}
+          {{/if}}
+          
+          {{#if this.isJobWithCodelist}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="task-codelist-uri"
@@ -65,54 +67,22 @@
                 {{on "change" (fn this.setProperty "codelistUri")}}
               />
             </AuFormRow>
+            
             <AuFormRow @alignment="default">
-              <AuLabel for="task-decisions-uri">
-                Decisions to map
-              </AuLabel>
-              <AuTextarea
-                id="task-decisions-uri"
-                @width="block"
-                value={{this.decisionUris}}
-                placeholder="Every line is a decision URI; leave blank to apply to all decisions"
-                {{on "change" (fn this.setProperty "decisionUris")}}
-              />
-            </AuFormRow>
-            <AuFormRow @alignment="default">
-              <AuLabel for="graph-for-targets-uri">
-                Decisions graph
+              <AuLabel for="confidence-threshold">
+                Confidence threshold
               </AuLabel>
               <AuInput
-                id="graph-for-targets-uri"
+                id="confidence-threshold"
                 @width="block"
-                value={{this.graphForTargetsUri}}
-                {{on "change" (fn this.setProperty "graphForTargetsUri")}}
+                value={{this.confidenceThreshold}}
+                placeholder="An integer number between 0 and 100"
+                {{on "change" (fn this.setProperty "confidenceThreshold")}}
               />
             </AuFormRow>
-            <AuFormRow @alignment="default">
-              <AuLabel for="property-path-for-text-uri">
-                Property for decision content
-              </AuLabel>
-              <AuInput
-                id="property-path-for-text-uri"
-                @width="block"
-                value={{this.propertyPathForTextUri}}
-                placeholder="https://data.europarl.europa.eu/def/epvoc#expressionContent"
-                {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
-              />
-            </AuFormRow>
-          <AuFormRow @alignment="default">
-            <AuLabel for="confidence-threshold">
-              Confidence threshold
-            </AuLabel>
-            <AuInput
-              id="confidence-threshold"
-              @width="block"
-              value={{this.confidenceThreshold}}
-              placeholder="An integer number between 0 and 100"
-              {{on "change" (fn this.setProperty "confidenceThreshold")}}
-            />
-          </AuFormRow>
-          {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
+          {{/if}}
+
+          {{#if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decisions-published-by">
                 Published by
@@ -153,7 +123,19 @@
                 </Group.Radio>
               </AuRadioGroup>
             </AuFormRow>
-          {{else if this.isJobWithMultipleEndpoints}}
+          {{/if}}
+
+          {{#if this.isJobWithDecisionSelector}}
+            <DecisionSelectorConfiguration
+            @decisionUris={{this.decisionUris}}
+            @graphForTargetsUri={{this.graphForTargetsUri}}
+            @targetClassUri={{this.targetClassUri}}
+            @propertyPathForTextUri={{this.propertyPathForTextUri}}
+            @setProperty={{this.setProperty}}
+            />
+          {{/if}}
+
+          {{#if this.isJobWithMultipleEndpoints}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="task-url"
@@ -173,7 +155,8 @@
                 All url values in this input should be separated by a new-line
               </AuHelpText>
             </AuFormRow>
-          {{else}}
+          {{/if}}
+          {{#if this.isJobWithSimpleUrl}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="task-url"
@@ -260,7 +243,8 @@
         {{/if}}
         {{#if (and this.authenticationEnabled
                    (not (eq this.selectedJobOperation.uri this.jobImport))
-                   (not (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)))}}
+                   (not (eq this.selectedJobOperation.uri this.jobHarvestOsloEli))
+                   (not (eq this.selectedJobOperation.uri this.jobEliToNERAndNEL)))}}
           <AuthenticationConfiguration
             @options={{this.securitySchemesOptions}}
             @selected={{this.selectedSecurityScheme}}

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -156,7 +156,7 @@
               </AuHelpText>
             </AuFormRow>
           {{/if}}
-          {{#if this.isJobWithSimpleUrl}}
+          {{#if this.isJobWithSingleUrl}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="task-url"
@@ -175,7 +175,7 @@
             </AuFormRow>
           {{/if}}
 
-          {{#if (eq this.selectedJobOperation.uri this.jobHarvestPdfToELI)}}
+          {{#if this.isJobWithMunicipality}}
             <AuFormRow @alignment="default">
               <AuLabel for="decision-passed-by">
                 Municipality

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -30,7 +30,7 @@
         </PowerSelect>
       </AuFormRow>
       {{#if this.selectedJobOperation.uri}}
-          {{#if this.isJobWithGraphName}}
+          {{#if (this.isJobWithGraphName this.selectedJobOperation.uri)}}
             <AuFormRow @alignment="default">
               <AuLabel
                 for="graph-name"
@@ -242,9 +242,7 @@
           </AuFormRow>
         {{/if}}
         {{#if (and this.authenticationEnabled
-                   (not (eq this.selectedJobOperation.uri this.jobImport))
-                   (not (eq this.selectedJobOperation.uri this.jobHarvestOsloEli))
-                   (not (eq this.selectedJobOperation.uri this.jobEliToNERAndNEL)))}}
+                   this.isJobWithAuthentication)}}
           <AuthenticationConfiguration
             @options={{this.securitySchemesOptions}}
             @selected={{this.selectedSecurityScheme}}

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -262,7 +262,7 @@
           </AuFormRow>
         {{/if}}
         {{#if (and this.authenticationEnabled
-                   (not (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)))}}
+                   this.isJobWithAuthentication)}}
           <AuthenticationConfiguration
             @options={{this.securitySchemesOptions}}
             @selected={{this.selectedSecurityScheme}}

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -47,7 +47,7 @@
             {{on "change" (fn this.setProperty "title")}}
           />
         </AuFormRow>
-        {{#if (or (eq this.selectedJobOperation.uri this.jobCodelistMappingTraining) (eq this.selectedJobOperation.uri this.jobCodelistMappingEvaluation))}}
+        {{#if this.isJobWithCodelist}}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-codelist-uri"
@@ -66,41 +66,6 @@
             />
           </AuFormRow>
           <AuFormRow @alignment="default">
-            <AuLabel for="task-decisions-uri">
-              Decision to map
-            </AuLabel>
-            <AuTextarea
-              id="task-decisions-uri"
-              @width="block"
-              value={{this.decisionUris}}
-              placeholder="Every line is a decision URI; leave blank to apply to all decisions"
-              {{on "change" (fn this.setProperty "decisionUris")}}
-            />
-          </AuFormRow>
-          <AuFormRow @alignment="default">
-            <AuLabel for="graph-for-targets-uri">
-              Decisions graph
-            </AuLabel>
-            <AuInput
-              id="graph-for-targets-uri"
-              @width="block"
-              value={{this.graphForTargetsUri}}
-              {{on "change" (fn this.setProperty "graphForTargetsUri")}}
-            />
-          </AuFormRow>
-          <AuFormRow @alignment="default">
-            <AuLabel for="property-path-for-text-uri">
-              Property for decision content
-            </AuLabel>
-            <AuInput
-              id="property-path-for-text-uri"
-              @width="block"
-              value={{this.propertyPathForTextUri}}
-              placeholder="https://data.europarl.europa.eu/def/epvoc#expressionContent"
-              {{on "change" (fn this.setProperty "propertyPathForTextUri")}}
-            />
-          </AuFormRow>
-          <AuFormRow @alignment="default">
             <AuLabel for="confidence-threshold">
               Confidence threshold
             </AuLabel>
@@ -112,7 +77,9 @@
               {{on "change" (fn this.setProperty "confidenceThreshold")}}
             />
           </AuFormRow>
-        {{else if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
+        {{/if}}
+
+        {{#if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
             <AuFormRow @alignment="default">
               <AuLabel for="decisions-published-by">
                 Published by
@@ -156,7 +123,19 @@
                 Initial sync is a one-time run and should be started as a single harvesting job. A scheduled job for delta sync is ideal to keep data up to date.
               </AuHelpText>
             </AuFormRow>
-        {{else if this.isJobWithMultipleEndpoints}}
+        {{/if}}
+
+          {{#if this.isJobWithDecisionSelector}}
+            <DecisionSelectorConfiguration
+              @decisionUris={{this.decisionUris}}
+              @graphForTargetsUri={{this.graphForTargetsUri}}
+              @targetClassUri={{this.targetClassUri}}
+              @propertyPathForTextUri={{this.propertyPathForTextUri}}
+              @setProperty={{this.setProperty}}
+            />
+          {{/if}}
+
+        {{#if this.isJobWithMultipleEndpoints}}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-url"
@@ -176,7 +155,9 @@
               All url values in this input should be separated by a new-line
             </AuHelpText>
           </AuFormRow>
-        {{else}}
+        {{/if}}
+
+        {{#if this.isJobWithSingleUrl}}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-url"
@@ -194,6 +175,27 @@
             />
           </AuFormRow>
         {{/if}}
+
+        {{#if this.isJobWithMunicipality}}
+          <AuFormRow @alignment="default">
+            <AuLabel for="decision-passed-by">
+              Municipality
+            </AuLabel>
+            <PowerSelect
+              id="decision-passed-by"
+              @searchEnabled={{true}}
+              @searchField="label"
+              @options={{this.municipalities}}
+              @selected={{this.selectedMunicipality}}
+              @onChange={{this.changeSelectedMunicipality}}
+              @renderInPlace={{true}}
+              @disabled={{or this.loadingMunicipalities (not this.municipalities.length)}}
+              as |option|>
+              {{option.label}}
+            </PowerSelect>
+          </AuFormRow>
+        {{/if}}
+
         <AuFormRow @alignment="default">
           <AuLabel
             for="cron-pattern"

--- a/app/transforms/number.js
+++ b/app/transforms/number.js
@@ -1,0 +1,1 @@
+export { NumberTransform as default } from '@ember-data/serializer/transform';

--- a/app/transforms/string.js
+++ b/app/transforms/string.js
@@ -1,0 +1,1 @@
+export { StringTransform as default } from '@ember-data/serializer/transform';

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -73,7 +73,7 @@ JOB_OP_TYPES.set(
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OPARL, 'Harvest OParl API & Publish');
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
-  'Harvest direct PDF links & Publish as ELI',
+  'Harvest direct PDF link & Publish as ELI',
 );
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_PDF_SCRAPING,
@@ -120,7 +120,7 @@ if (['true', 'True', 'TRUE', true].includes(config.harvester.oparlHarvesting)) {
 if (['true', 'True', 'TRUE', true].includes(config.harvester.pdfHarvesting)) {
   JOB_OP_TYPE_CREATE.set(
     JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
-    'Harvest direct PDF links & Publish as ELI',
+    'Harvest direct PDF link & Publish as ELI',
   );
   JOB_OP_TYPE_CREATE.set(
     JOB_OP_TYPE_PDF_SCRAPING,

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -71,8 +71,14 @@ JOB_OP_TYPES.set(
   'Harvest Worship & Publish',
 );
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OPARL, 'Harvest OParl API & Publish');
-JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_PDF_TO_ELI, 'Harvest PDF to ELI');
-JOB_OP_TYPES.set(JOB_OP_TYPE_PDF_SCRAPING, 'PDF url scraping');
+JOB_OP_TYPES.set(
+  JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
+  'Harvest direct PDF links to ELI',
+);
+JOB_OP_TYPES.set(
+  JOB_OP_TYPE_PDF_SCRAPING,
+  'Harvest PDFs from Website URL & Publish as ELI',
+);
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI, 'Harvest OSLO to ELI');
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS,

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -180,6 +180,63 @@ JOB_OP_STATUS.set(JOB_OP_STATUS_CANCELED, 'Canceled');
 export const JOB_CREATOR_SELF_SERVICE =
   'http://lblod.data.gift/services/job-self-service';
 
+export function isJobWithGraphName(jobOperationUri) {
+  return [JOB_OP_TYPE_IMPORT].includes(jobOperationUri);
+}
+
+export function isJobWithSingleUrl(jobOperationUri) {
+  return [
+    JOB_OP_TYPE_HARVEST,
+    JOB_OP_TYPE_HARVEST_AND_IMPORT,
+    JOB_OP_TYPE_HARVEST_WORSHIP,
+    JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT,
+    JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI,
+    JOB_OP_TYPE_HARVESTING_OPARL,
+    JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
+  ].includes(jobOperationUri);
+}
+
+export function isJobWithMultipleEndpoints(jobOperationUri) {
+  return [JOB_OP_TYPE_PDF_SCRAPING].includes(jobOperationUri);
+}
+
+export function isJobWithCodelist(jobOperationUri) {
+  return [
+    JOB_OP_TYPE_CODELIST_MAPPING_TRAINING,
+    JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION,
+  ].includes(jobOperationUri);
+}
+
+export function isJobWithDecisionUris(jobOperationUri) {
+  return [
+    JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION,
+    JOB_OP_TYPE_CODELIST_MAPPING_TRAINING,
+  ].includes(jobOperationUri);
+}
+
+export function isJobWithDecisionSelector(jobOperationUri) {
+  return [
+    JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS,
+    JOB_OP_TYPE_CODELIST_MAPPING_TRAINING,
+    JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION,
+  ].includes(jobOperationUri);
+}
+
+export function isJobWithMunicipality(jobOperationUri) {
+  return [JOB_OP_TYPE_HARVESTING_PDF_TO_ELI, JOB_OP_TYPE_PDF_SCRAPING].includes(
+    jobOperationUri,
+  );
+}
+
+export function isJobWithAuthentication(jobOperationUri) {
+  return [
+    JOB_OP_TYPE_HARVEST,
+    JOB_OP_TYPE_HARVEST_AND_IMPORT,
+    JOB_OP_TYPE_HARVEST_WORSHIP,
+    JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT,
+  ].includes(jobOperationUri);
+}
+
 export const REQUEST_HEADERS = new Map();
 REQUEST_HEADERS.set(
   JOB_OP_TYPE_HARVEST,

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -73,7 +73,7 @@ JOB_OP_TYPES.set(
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OPARL, 'Harvest OParl API & Publish');
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
-  'Harvest direct PDF links to ELI',
+  'Harvest direct PDF links & Publish as ELI',
 );
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_PDF_SCRAPING,
@@ -120,9 +120,12 @@ if (['true', 'True', 'TRUE', true].includes(config.harvester.oparlHarvesting)) {
 if (['true', 'True', 'TRUE', true].includes(config.harvester.pdfHarvesting)) {
   JOB_OP_TYPE_CREATE.set(
     JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
-    'Harvest PDF & Publish as ELI',
+    'Harvest direct PDF links & Publish as ELI',
   );
-  JOB_OP_TYPE_CREATE.set(JOB_OP_TYPE_PDF_SCRAPING, 'PDF url scraping');
+  JOB_OP_TYPE_CREATE.set(
+    JOB_OP_TYPE_PDF_SCRAPING,
+    'Harvest PDFs from Website URL & Publish as ELI',
+  );
 }
 if (['true', 'True', 'TRUE', true].includes(config.harvester.osloHarvesting)) {
   JOB_OP_TYPE_CREATE.set(

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -179,3 +179,33 @@ JOB_OP_STATUS.set(JOB_OP_STATUS_CANCELED, 'Canceled');
 
 export const JOB_CREATOR_SELF_SERVICE =
   'http://lblod.data.gift/services/job-self-service';
+
+export const REQUEST_HEADERS = new Map();
+REQUEST_HEADERS.set(
+  JOB_OP_TYPE_HARVEST,
+  'http://data.lblod.info/request-headers/accept/text/html',
+);
+REQUEST_HEADERS.set(
+  JOB_OP_TYPE_HARVEST_WORSHIP,
+  'http://data.lblod.info/request-headers/accept/text/html',
+);
+REQUEST_HEADERS.set(
+  JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT,
+  'http://data.lblod.info/request-headers/accept/text/html',
+);
+REQUEST_HEADERS.set(
+  JOB_OP_TYPE_HARVEST_AND_IMPORT,
+  'http://data.lblod.info/request-headers/accept/text/html',
+);
+REQUEST_HEADERS.set(
+  JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
+  'http://data.lblod.info/request-headers/accept/application/pdf',
+);
+REQUEST_HEADERS.set(
+  JOB_OP_TYPE_PDF_SCRAPING,
+  'http://data.lblod.info/request-headers/accept/text/html',
+);
+REQUEST_HEADERS.set(
+  JOB_OP_TYPE_HARVESTING_OPARL,
+  'http://data.lblod.info/request-headers/accept/application/json',
+);

--- a/tests/integration/components/decision-selector-configuration-test.js
+++ b/tests/integration/components/decision-selector-configuration-test.js
@@ -1,21 +1,24 @@
+/* eslint-disable qunit/require-expect */
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, fillIn, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module('Integration | Component | decision-selector-configuration', function (hooks) {
-  setupRenderingTest(hooks);
+module(
+  'Integration | Component | decision-selector-configuration',
+  function (hooks) {
+    setupRenderingTest(hooks);
 
-  test('it renders all fields with passed values', async function (assert) {
-    this.setProperties({
-      decisionUris: 'uri-1\nuri-2',
-      graphForTargetsUri: 'graph-uri',
-      targetClassUri: 'class-uri',
-      propertyPathForTextUri: 'path-uri',
-      setProperty: () => {}
-    });
+    test('it renders all fields with passed values', async function (assert) {
+      this.setProperties({
+        decisionUris: 'uri-1\nuri-2',
+        graphForTargetsUri: 'graph-uri',
+        targetClassUri: 'class-uri',
+        propertyPathForTextUri: 'path-uri',
+        setProperty: () => {},
+      });
 
-    await render(hbs`<DecisionSelectorConfiguration
+      await render(hbs`<DecisionSelectorConfiguration
       @decisionUris={{this.decisionUris}}
       @graphForTargetsUri={{this.graphForTargetsUri}}
       @targetClassUri={{this.targetClassUri}}
@@ -23,73 +26,74 @@ module('Integration | Component | decision-selector-configuration', function (ho
       @setProperty={{this.setProperty}}
     />`);
 
-    assert.dom('#task-decisions-uri').hasValue('uri-1\nuri-2');
-    assert.dom('#graph-for-targets-uri').hasValue('graph-uri');
-    assert.dom('#target-class-uri').hasValue('class-uri');
-    assert.dom('#property-path-for-text-uri').hasValue('path-uri');
-  });
-
-  test('it calls setProperty when decisionUris textarea changes', async function (assert) {
-    assert.expect(2);
-
-    this.set('setProperty', (key, event) => {
-      assert.strictEqual(key, 'decisionUris');
-      assert.strictEqual(event.target.value, 'new value');
+      assert.dom('#task-decisions-uri').hasValue('uri-1\nuri-2');
+      assert.dom('#graph-for-targets-uri').hasValue('graph-uri');
+      assert.dom('#target-class-uri').hasValue('class-uri');
+      assert.dom('#property-path-for-text-uri').hasValue('path-uri');
     });
 
-    await render(hbs`<DecisionSelectorConfiguration
+    test('it calls setProperty when decisionUris textarea changes', async function (assert) {
+      assert.expect(2);
+
+      this.set('setProperty', (key, event) => {
+        assert.strictEqual(key, 'decisionUris');
+        assert.strictEqual(event.target.value, 'new value');
+      });
+
+      await render(hbs`<DecisionSelectorConfiguration
       @decisionUris=""
       @setProperty={{this.setProperty}}
     />`);
 
-    await fillIn('#task-decisions-uri', 'new value');
-  });
-
-  test('it calls setProperty when graphForTargetsUri input changes', async function (assert) {
-    assert.expect(2);
-
-    this.set('setProperty', (key, event) => {
-      assert.strictEqual(key, 'graphForTargetsUri');
-      assert.strictEqual(event.target.value, 'new graph');
+      await fillIn('#task-decisions-uri', 'new value');
     });
 
-    await render(hbs`<DecisionSelectorConfiguration
+    test('it calls setProperty when graphForTargetsUri input changes', async function (assert) {
+      assert.expect(2);
+
+      this.set('setProperty', (key, event) => {
+        assert.strictEqual(key, 'graphForTargetsUri');
+        assert.strictEqual(event.target.value, 'new graph');
+      });
+
+      await render(hbs`<DecisionSelectorConfiguration
       @graphForTargetsUri=""
       @setProperty={{this.setProperty}}
     />`);
 
-    await fillIn('#graph-for-targets-uri', 'new graph');
-  });
-
-  test('it calls setProperty when targetClassUri input changes', async function (assert) {
-    assert.expect(2);
-
-    this.set('setProperty', (key, event) => {
-      assert.strictEqual(key, 'targetClassUri');
-      assert.strictEqual(event.target.value, 'new class');
+      await fillIn('#graph-for-targets-uri', 'new graph');
     });
 
-    await render(hbs`<DecisionSelectorConfiguration
+    test('it calls setProperty when targetClassUri input changes', async function (assert) {
+      assert.expect(2);
+
+      this.set('setProperty', (key, event) => {
+        assert.strictEqual(key, 'targetClassUri');
+        assert.strictEqual(event.target.value, 'new class');
+      });
+
+      await render(hbs`<DecisionSelectorConfiguration
       @targetClassUri=""
       @setProperty={{this.setProperty}}
     />`);
 
-    await fillIn('#target-class-uri', 'new class');
-  });
-
-  test('it calls setProperty when propertyPathForTextUri textarea changes', async function (assert) {
-    assert.expect(2);
-
-    this.set('setProperty', (key, event) => {
-      assert.strictEqual(key, 'propertyPathForTextUri');
-      assert.strictEqual(event.target.value, 'new path');
+      await fillIn('#target-class-uri', 'new class');
     });
 
-    await render(hbs`<DecisionSelectorConfiguration
+    test('it calls setProperty when propertyPathForTextUri textarea changes', async function (assert) {
+      assert.expect(2);
+
+      this.set('setProperty', (key, event) => {
+        assert.strictEqual(key, 'propertyPathForTextUri');
+        assert.strictEqual(event.target.value, 'new path');
+      });
+
+      await render(hbs`<DecisionSelectorConfiguration
       @propertyPathForTextUri=""
       @setProperty={{this.setProperty}}
     />`);
 
-    await fillIn('#property-path-for-text-uri', 'new path');
-  });
-});
+      await fillIn('#property-path-for-text-uri', 'new path');
+    });
+  },
+);

--- a/tests/integration/components/decision-selector-configuration-test.js
+++ b/tests/integration/components/decision-selector-configuration-test.js
@@ -1,7 +1,7 @@
 /* eslint-disable qunit/require-expect */
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, fillIn, triggerEvent } from '@ember/test-helpers';
+import { render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module(

--- a/tests/integration/components/decision-selector-configuration-test.js
+++ b/tests/integration/components/decision-selector-configuration-test.js
@@ -1,29 +1,95 @@
 import { module, test } from 'qunit';
-import { setupRenderingTest } from 'frontend-harvesting-self-service/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, fillIn, triggerEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module(
-  'Integration | Component | decision-selector-configuration',
-  function (hooks) {
-    setupRenderingTest(hooks);
+module('Integration | Component | decision-selector-configuration', function (hooks) {
+  setupRenderingTest(hooks);
 
-    test('it renders', async function (assert) {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.set('myAction', function(val) { ... });
-
-      await render(hbs`<DecisionSelectorConfiguration />`);
-
-      assert.dom().hasText('');
-
-      // Template block usage:
-      await render(hbs`
-      <DecisionSelectorConfiguration>
-        template block text
-      </DecisionSelectorConfiguration>
-    `);
-
-      assert.dom().hasText('template block text');
+  test('it renders all fields with passed values', async function (assert) {
+    this.setProperties({
+      decisionUris: 'uri-1\nuri-2',
+      graphForTargetsUri: 'graph-uri',
+      targetClassUri: 'class-uri',
+      propertyPathForTextUri: 'path-uri',
+      setProperty: () => {}
     });
-  },
-);
+
+    await render(hbs`<DecisionSelectorConfiguration
+      @decisionUris={{this.decisionUris}}
+      @graphForTargetsUri={{this.graphForTargetsUri}}
+      @targetClassUri={{this.targetClassUri}}
+      @propertyPathForTextUri={{this.propertyPathForTextUri}}
+      @setProperty={{this.setProperty}}
+    />`);
+
+    assert.dom('#task-decisions-uri').hasValue('uri-1\nuri-2');
+    assert.dom('#graph-for-targets-uri').hasValue('graph-uri');
+    assert.dom('#target-class-uri').hasValue('class-uri');
+    assert.dom('#property-path-for-text-uri').hasValue('path-uri');
+  });
+
+  test('it calls setProperty when decisionUris textarea changes', async function (assert) {
+    assert.expect(2);
+
+    this.set('setProperty', (key, event) => {
+      assert.strictEqual(key, 'decisionUris');
+      assert.strictEqual(event.target.value, 'new value');
+    });
+
+    await render(hbs`<DecisionSelectorConfiguration
+      @decisionUris=""
+      @setProperty={{this.setProperty}}
+    />`);
+
+    await fillIn('#task-decisions-uri', 'new value');
+  });
+
+  test('it calls setProperty when graphForTargetsUri input changes', async function (assert) {
+    assert.expect(2);
+
+    this.set('setProperty', (key, event) => {
+      assert.strictEqual(key, 'graphForTargetsUri');
+      assert.strictEqual(event.target.value, 'new graph');
+    });
+
+    await render(hbs`<DecisionSelectorConfiguration
+      @graphForTargetsUri=""
+      @setProperty={{this.setProperty}}
+    />`);
+
+    await fillIn('#graph-for-targets-uri', 'new graph');
+  });
+
+  test('it calls setProperty when targetClassUri input changes', async function (assert) {
+    assert.expect(2);
+
+    this.set('setProperty', (key, event) => {
+      assert.strictEqual(key, 'targetClassUri');
+      assert.strictEqual(event.target.value, 'new class');
+    });
+
+    await render(hbs`<DecisionSelectorConfiguration
+      @targetClassUri=""
+      @setProperty={{this.setProperty}}
+    />`);
+
+    await fillIn('#target-class-uri', 'new class');
+  });
+
+  test('it calls setProperty when propertyPathForTextUri textarea changes', async function (assert) {
+    assert.expect(2);
+
+    this.set('setProperty', (key, event) => {
+      assert.strictEqual(key, 'propertyPathForTextUri');
+      assert.strictEqual(event.target.value, 'new path');
+    });
+
+    await render(hbs`<DecisionSelectorConfiguration
+      @propertyPathForTextUri=""
+      @setProperty={{this.setProperty}}
+    />`);
+
+    await fillIn('#property-path-for-text-uri', 'new path');
+  });
+});

--- a/tests/integration/components/decision-selector-configuration-test.js
+++ b/tests/integration/components/decision-selector-configuration-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-harvesting-self-service/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module(
+  'Integration | Component | decision-selector-configuration',
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('it renders', async function (assert) {
+      // Set any properties with this.set('myProperty', 'value');
+      // Handle any actions with this.set('myAction', function(val) { ... });
+
+      await render(hbs`<DecisionSelectorConfiguration />`);
+
+      assert.dom().hasText('');
+
+      // Template block usage:
+      await render(hbs`
+      <DecisionSelectorConfiguration>
+        template block text
+      </DecisionSelectorConfiguration>
+    `);
+
+      assert.dom().hasText('template block text');
+    });
+  },
+);


### PR DESCRIPTION
## 🗒️ Description
The first purpose was to add a list of decision URIs to test, for the enrichment (NER/NEL) pipeline
The scope went further by also adding:

- rewrote the way how the form was build by introducing getters for "codelist", "decision selector configuration", "single URL", "multi URL", "municipality"
- Add Component for decision selector configuration to prevent duplication of code
- Property path for text is now a string (instead of URL) where a SPARQL property path is expected
- Add targetClass field (and by default eli:Work instead of eli:Expression)
- Renamed Harvest PDF to Harvest direct PDF link & Publish as ELI
- Renamed PDF scrape to Harvest PDFs from Website URL & Publish as ELI
- Add "Municipality" selector to Harvest PDFs from Website

## 🦮 How to test

Use branch of app-decide: https://github.com/lblod/app-decide/pull/80

Run the frontend with `npm run dev:proxy`

1. Create a standalone job (test all types, because the way the form is built has changed)
- Oparl job, you can use URL = https://ris.freiburg.de/oparl/Body/FR/paper/page/137
- Harvest direct PDF link, you can use URL = https://ebesluitvorming.gent.be/document/699ed4a96c21b613fc17617e with municipality "Gent"
- Harvest PDFs from website, you can use URL's: https://district09.gent/nl/over-ons/wettelijke-documenten/besluiten-overlegorgaan
- Perform named entity recognition etc, you can leave decisions to map blank and just click create, or add a decision URI, such as = https://data.gent.be/id/besluiten/26.0220.9871.6419
- Codelist mapping (training/evaluation), use codelist URI = http://data.lblod.gift/id/conceptscheme/sdg-simple
3. Create a scheduled job

## 🔗 Links to other PR's

- https://github.com/lblod/app-decide/pull/80

## 🖼️ Attachments

- Renamed Harvest PDF to ELI to Harvest direct PDF url
<img width="948" height="878" alt="image" src="https://github.com/user-attachments/assets/d342fc8d-35f9-4453-81d3-b93072da6f51" />

- Renamed Scrape PDF to Harvest PDF from website AND added selector of municipalities
<img width="996" height="841" alt="image" src="https://github.com/user-attachments/assets/334a9b3c-67e6-434c-8da9-acbc4ec82625" />

- Perform NER and NEL has now decision configuration options (which was the original intent of the PR)

<img width="948" height="878" alt="image" src="https://github.com/user-attachments/assets/968f7730-876d-4094-8804-8aea5eb58c66" />

- Property path for text is now a string and added target class. And enabled this for the codelist mapping tasks (evaluation, training) too:
<img width="948" height="878" alt="image" src="https://github.com/user-attachments/assets/1b0c18c6-b3f8-4d8d-b67a-9acd13cbbed3" />

- Running the enrichment pipeline on two fictive decision URIs:

<img width="948" height="878" alt="image" src="https://github.com/user-attachments/assets/0b6f1d3b-647b-449c-93c3-3f48f8324789" />

Results in these triples:
<img width="1658" height="438" alt="image" src="https://github.com/user-attachments/assets/cadd09da-abf3-4331-ad02-fb65003d48a9" />

<img width="1658" height="438" alt="image" src="https://github.com/user-attachments/assets/e4ea78da-b929-4283-ba25-085b92b8981f" />

and when no decisionUris are given:
<img width="1658" height="438" alt="image" src="https://github.com/user-attachments/assets/5f639b4e-65a9-4456-b5d8-7c8a5a612482" />


 