### PR TITLE
Always create an input container, no matter the input

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -262,39 +262,47 @@ export default class OverviewJobsNewController extends Controller {
           sources.push(source.trim());
         });
       }
-      const remoteDataObjects = sources.map((source) => {
-        return this.store.createRecord('remote-data-object', {
-          source,
-          // This is deliberate, the collector service will set the status and
-          // therefore start the job later:
-          status: undefined,
-          requestHeader: this.request_headers.has(this.selectedJobOperation.uri)
-            ? this.request_headers.get(this.selectedJobOperation.uri)
-            : undefined,
-          created: this.currentTime,
-          modified: this.currentTime,
-          creator: this.creator,
-        });
-      });
-      await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
-      const collection = this.store.createRecord('harvesting-collection', {
-        creator: this.creator,
-        authenticationConfiguration: this.selectedSecurityScheme
-          ? await createAuthenticationConfiguration(
-              this.selectedSecurityScheme,
-              this.securityScheme,
-              this.credentials,
-              this.store,
+      if (sources.length > 0) {
+        const remoteDataObjects = sources.map((source) => {
+          return this.store.createRecord('remote-data-object', {
+            source,
+            // This is deliberate, the collector service will set the status and
+            // therefore start the job later:
+            status: undefined,
+            requestHeader: this.request_headers.has(
+              this.selectedJobOperation.uri,
             )
-          : null, // authenticationConfiguration is optional
-        remoteDataObjects: remoteDataObjects,
-      });
-      await collection.save();
-
-      dataContainer = this.store.createRecord('data-container', {
-        harvestingCollections: [collection],
-      });
-      await dataContainer.save();
+              ? this.request_headers.get(this.selectedJobOperation.uri)
+              : undefined,
+            created: this.currentTime,
+            modified: this.currentTime,
+            creator: this.creator,
+          });
+        });
+        await Promise.all(
+          remoteDataObjects.map(async (rdo) => await rdo.save()),
+        );
+        const collection = this.store.createRecord('harvesting-collection', {
+          creator: this.creator,
+          authenticationConfiguration: this.selectedSecurityScheme
+            ? await createAuthenticationConfiguration(
+                this.selectedSecurityScheme,
+                this.securityScheme,
+                this.credentials,
+                this.store,
+              )
+            : null, // authenticationConfiguration is optional
+          remoteDataObjects: remoteDataObjects,
+        });
+        await collection.save();
+        dataContainer = this.store.createRecord('data-container', {
+          harvestingCollections: [collection],
+        });
+        await dataContainer.save();
+      } else {
+        dataContainer = this.store.createRecord('data-container', {});
+        await dataContainer.save();
+      }
       inputContainers.push(dataContainer);
 
       if (this.selectedJobOperation.uri === this.jobHarvestPdfToELI) {

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -275,42 +275,49 @@ export default class OverviewScheduledJobsNewController extends Controller {
           sources.push(source.trim());
         });
       }
-      const remoteDataObjects = sources.map((source) => {
-        return this.store.createRecord('remote-data-object', {
-          source: source,
-          status: undefined,
-          requestHeader:
-            'http://data.lblod.info/request-headers/accept/text/html',
-          created: this.currentTime,
-          modified: this.currentTime,
-          creator: this.creator,
+      if (sources.length > 0) {
+        const remoteDataObjects = sources.map((source) => {
+          return this.store.createRecord('remote-data-object', {
+            source: source,
+            status: undefined,
+            requestHeader:
+              'http://data.lblod.info/request-headers/accept/text/html',
+            created: this.currentTime,
+            modified: this.currentTime,
+            creator: this.creator,
+          });
         });
-      });
 
-      await Promise.all(remoteDataObjects.map(async (rdo) => await rdo.save()));
-      const collection = this.store.createRecord('harvesting-collection', {
-        creator: this.creator,
-        //TODO: authentication configuration doesn't work currently for scheduled jobs. Because
-        // - Shallow copy of authtentication configuration (see DL-4896)
-        // - See timing issue comments, in controllers/jobs/new.js
-        authenticationConfiguration: this.selectedSecurityScheme
-          ? await createAuthenticationConfiguration(
-              this.selectedSecurityScheme,
-              this.securityScheme,
-              this.credentials,
-              this.store,
-            )
-          : null, // authenticationConfiguration is optional
-        remoteDataObjects: remoteDataObjects,
-      });
-      await collection.save();
+        await Promise.all(
+          remoteDataObjects.map(async (rdo) => await rdo.save()),
+        );
+        const collection = this.store.createRecord('harvesting-collection', {
+          creator: this.creator,
+          //TODO: authentication configuration doesn't work currently for scheduled jobs. Because
+          // - Shallow copy of authtentication configuration (see DL-4896)
+          // - See timing issue comments, in controllers/jobs/new.js
+          authenticationConfiguration: this.selectedSecurityScheme
+            ? await createAuthenticationConfiguration(
+                this.selectedSecurityScheme,
+                this.securityScheme,
+                this.credentials,
+                this.store,
+              )
+            : null, // authenticationConfiguration is optional
+          remoteDataObjects: remoteDataObjects,
+        });
+        await collection.save();
 
-      const dataContainer = this.store.createRecord('data-container', {
-        harvestingCollections: [collection],
-      });
-      await dataContainer.save();
-
-      inputContainers.push(dataContainer);
+        const dataContainer = this.store.createRecord('data-container', {
+          harvestingCollections: [collection],
+        });
+        await dataContainer.save();
+        inputContainers.push(dataContainer);
+      } else {
+        const dataContainer = this.store.createRecord('data-container', {});
+        await dataContainer.save();
+        inputContainers.push(dataContainer);
+      }
 
       const scheduledTask = this.store.createRecord('scheduled-task', {
         created: this.currentTime,


### PR DESCRIPTION
For some job type (e.g. NER/NEL and codelist mapping) no `sources` are set as input. This situation leads to the input container not being saved and linked to the first task correctly. To make sure there is ALWAYS an input container available for the first task (it may even be empty), a check is added:
- If `sources` is not empty, run the "normal" flow, i.e. create input container content, create the input container and link it to the first task
- If ``sources` is empty, skip the "normal" flow, create an empty input container and link it to the first task.

To test, use this feature branch's image in override:
```yml
services:
  frontend-harvesting:
    image: lblod/frontend-harvesting-self-service:feature-oparl-harvesting
```
And try creating an NER/NEL or codelist mapping job. The first task, namely the singleton job task should run succesfully AND the next task should be started.