### PR TITLE
Require decisions or decision graph field to be filled in

### DIFF
--- a/app/components/decision-selector-configuration.hbs
+++ b/app/components/decision-selector-configuration.hbs
@@ -1,23 +1,29 @@
 <AuFormRow @alignment="default">
-    <AuLabel for="task-decisions-uri">
+    <AuLabel
+    for="task-decisions-uri"
+    @error={{eq @decisionUrisValid false}}>
     Decisions to map
     </AuLabel>
     <AuTextarea
     id="task-decisions-uri"
     @width="block"
     value={{@decisionUris}}
+    @error={{eq @decisionUrisValid false}}
     placeholder="Every line is a decision URI; leave blank to apply to all decisions"
     {{on "change" (fn @setProperty "decisionUris")}}
     />
 </AuFormRow>
 <AuFormRow @alignment="default">
-    <AuLabel for="graph-for-targets-uri">
+    <AuLabel
+    for="graph-for-targets-uri"
+    @error={{eq @graphForTargetsUriValid false}}>
     Decisions graph
     </AuLabel>
     <AuInput
     id="graph-for-targets-uri"
     @width="block"
     value={{@graphForTargetsUri}}
+    @error={{eq @graphForTargetsUriValid false}}
     {{on "change" (fn @setProperty "graphForTargetsUri")}}
     />
 </AuFormRow>

--- a/app/components/decision-selector-configuration.hbs
+++ b/app/components/decision-selector-configuration.hbs
@@ -1,6 +1,8 @@
 <AuFormRow @alignment="default">
     <AuLabel
     for="task-decisions-uri"
+    @required={{true}}
+    @requiredLabel="Required if no decisions graph"
     @error={{eq @decisionUrisValid false}}>
     Decisions to map
     </AuLabel>
@@ -16,6 +18,8 @@
 <AuFormRow @alignment="default">
     <AuLabel
     for="graph-for-targets-uri"
+    @required={{true}}
+    @requiredLabel="Required if no decisions to map"
     @error={{eq @graphForTargetsUriValid false}}>
     Decisions graph
     </AuLabel>

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -164,7 +164,9 @@ export default class OverviewJobsNewController extends Controller {
     else this.vendorValid = false;
     this.codelistUriValid = !!this.codelistUri;
     this.targetClassUriValid = !!this.targetClassUri;
-    this.graphForTargetsUriValid = true;
+    const hasDecisionScope = !!(this.decisionUris || this.graphForTargetsUri);
+    this.decisionUrisValid = hasDecisionScope;
+    this.graphForTargetsUriValid = hasDecisionScope;
     this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
     this.confidenceThresholdValid = !isNaN(
       parseFloat(this.confidenceThreshold),

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -141,6 +141,12 @@ export default class OverviewJobsNewController extends Controller {
   setProperty(property, event) {
     this[property] = event.target.value;
     this[`${property}Valid`] = !!this[property];
+
+    if (property === 'decisionUris' || property === 'graphForTargetsUri') {
+      const hasScope = !!(this.decisionUris || this.graphForTargetsUri);
+      this.decisionUrisValid = hasScope;
+      this.graphForTargetsUriValid = hasScope;
+    }
   }
 
   @action

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -143,9 +143,9 @@ export default class OverviewJobsNewController extends Controller {
     this[`${property}Valid`] = !!this[property];
 
     if (property === 'decisionUris' || property === 'graphForTargetsUri') {
-      const hasScope = !!(this.decisionUris || this.graphForTargetsUri);
-      this.decisionUrisValid = hasScope;
-      this.graphForTargetsUriValid = hasScope;
+      const hasTarget = !!(this.decisionUris || this.graphForTargetsUri);
+      this.decisionUrisValid = hasTarget;
+      this.graphForTargetsUriValid = hasTarget;
     }
   }
 
@@ -170,9 +170,9 @@ export default class OverviewJobsNewController extends Controller {
     else this.vendorValid = false;
     this.codelistUriValid = !!this.codelistUri;
     this.targetClassUriValid = !!this.targetClassUri;
-    const hasDecisionScope = !!(this.decisionUris || this.graphForTargetsUri);
-    this.decisionUrisValid = hasDecisionScope;
-    this.graphForTargetsUriValid = hasDecisionScope;
+    const hasDecisionTarget = !!(this.decisionUris || this.graphForTargetsUri);
+    this.decisionUrisValid = hasDecisionTarget;
+    this.graphForTargetsUriValid = hasDecisionTarget;
     this.propertyPathForTextUriValid = !!this.propertyPathForTextUri;
     this.confidenceThresholdValid = !isNaN(
       parseFloat(this.confidenceThreshold),

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -161,6 +161,12 @@ export default class OverviewScheduledJobsNewController extends Controller {
   setProperty(property, event) {
     this[property] = event.target.value;
     this[`${property}Valid`] = !!this[property];
+
+    if (property === 'decisionUris' || property === 'graphForTargetsUri') {
+      const hasScope = !!(this.decisionUris || this.graphForTargetsUri);
+      this.decisionUrisValid = hasScope;
+      this.graphForTargetsUriValid = hasScope;
+    }
   }
 
   @action

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -180,7 +180,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.vendorValid = !!this.vendor;
     this.codelistUriValid = !!this.codelistUri;
     this.targetClassUriValid = !!this.targetClassUri;
-    this.graphForTargetsUriValid = true;
+    const hasDecisionScope = !!(this.decisionUris || this.graphForTargetsUri);
+    this.decisionUrisValid = hasDecisionScope;
+    this.graphForTargetsUriValid = hasDecisionScope;
     this.propertyPathForTextUriValid = true;
     this.confidenceThresholdValid = !isNaN(
       parseFloat(this.confidenceThreshold),

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -163,9 +163,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this[`${property}Valid`] = !!this[property];
 
     if (property === 'decisionUris' || property === 'graphForTargetsUri') {
-      const hasScope = !!(this.decisionUris || this.graphForTargetsUri);
-      this.decisionUrisValid = hasScope;
-      this.graphForTargetsUriValid = hasScope;
+      const hasTarget = !!(this.decisionUris || this.graphForTargetsUri);
+      this.decisionUrisValid = hasTarget;
+      this.graphForTargetsUriValid = hasTarget;
     }
   }
 
@@ -186,9 +186,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.vendorValid = !!this.vendor;
     this.codelistUriValid = !!this.codelistUri;
     this.targetClassUriValid = !!this.targetClassUri;
-    const hasDecisionScope = !!(this.decisionUris || this.graphForTargetsUri);
-    this.decisionUrisValid = hasDecisionScope;
-    this.graphForTargetsUriValid = hasDecisionScope;
+    const hasDecisionTarget = !!(this.decisionUris || this.graphForTargetsUri);
+    this.decisionUrisValid = hasDecisionTarget;
+    this.graphForTargetsUriValid = hasDecisionTarget;
     this.propertyPathForTextUriValid = true;
     this.confidenceThresholdValid = !isNaN(
       parseFloat(this.confidenceThreshold),

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -128,7 +128,9 @@
           {{#if this.isJobWithDecisionSelector}}
             <DecisionSelectorConfiguration
             @decisionUris={{this.decisionUris}}
+            @decisionUrisValid={{this.decisionUrisValid}}
             @graphForTargetsUri={{this.graphForTargetsUri}}
+            @graphForTargetsUriValid={{this.graphForTargetsUriValid}}
             @targetClassUri={{this.targetClassUri}}
             @propertyPathForTextUri={{this.propertyPathForTextUri}}
             @setProperty={{this.setProperty}}

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -128,7 +128,9 @@
           {{#if this.isJobWithDecisionSelector}}
             <DecisionSelectorConfiguration
               @decisionUris={{this.decisionUris}}
+              @decisionUrisValid={{this.decisionUrisValid}}
               @graphForTargetsUri={{this.graphForTargetsUri}}
+              @graphForTargetsUriValid={{this.graphForTargetsUriValid}}
               @targetClassUri={{this.targetClassUri}}
               @propertyPathForTextUri={{this.propertyPathForTextUri}}
               @setProperty={{this.setProperty}}


### PR DESCRIPTION
The NER/NEL and codelist mapping jobs require at least one of the following two fields to be filled in: "Decisions to map", "Decisions graph". In other words, when non of these two is filled in, you shouldn't be able to create the job.

Validation has been added to require this. Also, pills have been added to help the user understand at least one of the two fields should be filled in.

<img width="778" height="1086" alt="image" src="https://github.com/user-attachments/assets/92307b40-a8cc-4c7b-9f63-9ee164b5a7b1" />