### PR TITLE
Keep only one PDF handling job type

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -17,7 +17,6 @@ export default class OverviewJobsNewController extends Controller {
   jobCodelistMappingTraining = cts.JOB_OP_TYPE_CODELIST_MAPPING_TRAINING;
   jobCodelistMappingEvaluation = cts.JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
-  jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
   jobOparlToELI = cts.JOB_OP_TYPE_HARVESTING_OPARL;
 
@@ -304,7 +303,7 @@ export default class OverviewJobsNewController extends Controller {
       }
       inputContainers.push(dataContainer);
 
-      if (this.selectedJobOperation.uri === this.jobHarvestPdfToELI) {
+      if (this.isJobWithMunicipality) {
         dataContainerWithMunicipality = this.store.createRecord(
           'data-container',
           {

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -18,7 +18,6 @@ export default class OverviewJobsNewController extends Controller {
   jobCodelistMappingEvaluation = cts.JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
-  jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
   jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
   jobOparlToELI = cts.JOB_OP_TYPE_HARVESTING_OPARL;
 

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -313,6 +313,17 @@ export default class OverviewScheduledJobsNewController extends Controller {
         inputContainers.push(dataContainer);
       }
 
+      if (this.isJobWithMunicipality) {
+        const dataContainerWithMunicipality = this.store.createRecord(
+          'data-container',
+          {
+            hasResource: [this.selectedMunicipality.uri],
+          },
+        );
+        await dataContainerWithMunicipality.save();
+        inputContainers.push(dataContainerWithMunicipality);
+      }
+
       const scheduledTask = this.store.createRecord('scheduled-task', {
         created: this.currentTime,
         modified: this.currentTime,

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -18,18 +18,12 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobCodelistMappingTraining = cts.JOB_OP_TYPE_CODELIST_MAPPING_TRAINING;
   jobCodelistMappingEvaluation = cts.JOB_OP_TYPE_CODELIST_MAPPING_EVALUATION;
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
-  jobHarvestPdfToELI = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
-  jobPdfScraping = cts.JOB_OP_TYPE_PDF_SCRAPING;
   jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
   jobOparlToELI = cts.JOB_OP_TYPE_HARVESTING_OPARL;
 
-  jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE)
-    .filter(([key]) => {
-      return key !== this.jobHarvestPdfToELI; // Exclude the PDF to ELI job operation as this is supposed to be a one-time job
-    })
-    .map(([key, value]) => {
-      return { label: value, uri: key };
-    });
+  jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(([key, value]) => {
+    return { label: value, uri: key };
+  });
 
   creator = cts.JOB_CREATOR_SELF_SERVICE;
 

--- a/app/models/scheduled-job.js
+++ b/app/models/scheduled-job.js
@@ -28,6 +28,6 @@ export default class ScheduledJobModel extends Model {
   }
 
   get isJobWithMultipleEndpoints() {
-    return this.operation === cts.JOB_OP_TYPE_PDF_SCRAPING;
+    return this.operation === cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
   }
 }

--- a/app/utils/constants.js
+++ b/app/utils/constants.js
@@ -26,8 +26,6 @@ export const JOB_OP_TYPE_HARVESTING_OPARL =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/oparl';
 export const JOB_OP_TYPE_HARVESTING_PDF_TO_ELI =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-eli';
-export const JOB_OP_TYPE_PDF_SCRAPING =
-  'http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping';
 export const JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI =
   'http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/oslo-to-eli';
 export const JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS =
@@ -73,10 +71,6 @@ JOB_OP_TYPES.set(
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OPARL, 'Harvest OParl API & Publish');
 JOB_OP_TYPES.set(
   JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
-  'Harvest direct PDF link & Publish as ELI',
-);
-JOB_OP_TYPES.set(
-  JOB_OP_TYPE_PDF_SCRAPING,
   'Harvest PDFs from Website URL & Publish as ELI',
 );
 JOB_OP_TYPES.set(JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI, 'Harvest OSLO to ELI');
@@ -120,10 +114,6 @@ if (['true', 'True', 'TRUE', true].includes(config.harvester.oparlHarvesting)) {
 if (['true', 'True', 'TRUE', true].includes(config.harvester.pdfHarvesting)) {
   JOB_OP_TYPE_CREATE.set(
     JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
-    'Harvest direct PDF link & Publish as ELI',
-  );
-  JOB_OP_TYPE_CREATE.set(
-    JOB_OP_TYPE_PDF_SCRAPING,
     'Harvest PDFs from Website URL & Publish as ELI',
   );
 }
@@ -192,12 +182,11 @@ export function isJobWithSingleUrl(jobOperationUri) {
     JOB_OP_TYPE_HARVEST_WORSHIP_AND_IMPORT,
     JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI,
     JOB_OP_TYPE_HARVESTING_OPARL,
-    JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
   ].includes(jobOperationUri);
 }
 
 export function isJobWithMultipleEndpoints(jobOperationUri) {
-  return [JOB_OP_TYPE_PDF_SCRAPING].includes(jobOperationUri);
+  return [JOB_OP_TYPE_HARVESTING_PDF_TO_ELI].includes(jobOperationUri);
 }
 
 export function isJobWithCodelist(jobOperationUri) {
@@ -223,9 +212,7 @@ export function isJobWithDecisionSelector(jobOperationUri) {
 }
 
 export function isJobWithMunicipality(jobOperationUri) {
-  return [JOB_OP_TYPE_HARVESTING_PDF_TO_ELI, JOB_OP_TYPE_PDF_SCRAPING].includes(
-    jobOperationUri,
-  );
+  return [JOB_OP_TYPE_HARVESTING_PDF_TO_ELI].includes(jobOperationUri);
 }
 
 export function isJobWithAuthentication(jobOperationUri) {
@@ -256,10 +243,6 @@ REQUEST_HEADERS.set(
 );
 REQUEST_HEADERS.set(
   JOB_OP_TYPE_HARVESTING_PDF_TO_ELI,
-  'http://data.lblod.info/request-headers/accept/application/pdf',
-);
-REQUEST_HEADERS.set(
-  JOB_OP_TYPE_PDF_SCRAPING,
   'http://data.lblod.info/request-headers/accept/text/html',
 );
 REQUEST_HEADERS.set(


### PR DESCRIPTION
The `http://lblod.data.gift/id/jobs/concept/TaskOperation/pdf-scraping` job has been dropped in favor of `http://lblod.data.gift/id/jobs/concept/JobOperation/harvesting/pdf-to-eli`. However, the latter does take over the label `Harvest PDFs from Website URL & Publish as ELI` from the former (see screenshot).

At the same time, this PR ensures the municipality is always present on the input container, for both job and scheduled job.

<img width="773" height="725" alt="image" src="https://github.com/user-attachments/assets/dd655536-911b-4234-aa1c-f74ff0c0b9b7" />