### PR TITLE
feat: add split decisions toggle to new (scheduled) job form

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -19,6 +19,7 @@ export default class OverviewJobsNewController extends Controller {
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
   jobOparlToELI = cts.JOB_OP_TYPE_HARVESTING_OPARL;
+  jobHarvestPdfToEli = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
 
   @tracked jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(
     ([key, value]) => {
@@ -74,6 +75,8 @@ export default class OverviewJobsNewController extends Controller {
   @tracked municipalities = [];
   @tracked selectedMunicipality;
 
+  @tracked splitPdf = true;
+
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
     this.consumeLokaalBeslistPublishedByOptions[0];
@@ -109,6 +112,10 @@ export default class OverviewJobsNewController extends Controller {
   }
   get isJobWithAuthentication() {
     return cts.isJobWithAuthentication(this.selectedJobOperation?.uri);
+  }
+
+  get isHarvestPdfJob() {
+    return this.selectedJobOperation?.uri === this.jobHarvestPdfToEli;
   }
 
   @action
@@ -147,6 +154,11 @@ export default class OverviewJobsNewController extends Controller {
   @action
   changeSelectedMunicipality(org) {
     this.selectedMunicipality = org;
+  }
+
+  @action
+  toggleSplitPdf() {
+    this.splitPdf = !this.splitPdf;
   }
 
   @action
@@ -214,6 +226,10 @@ export default class OverviewJobsNewController extends Controller {
 
       if (this.isJobWithCodelist) {
         jobAttributes.codelist = this.codelistUri;
+      }
+
+      if (this.isHarvestPdfJob && this.splitPdf) {
+        jobAttributes.splitDecisions = this.splitPdf;
       }
 
       if (this.isJobWithDecisionSelector) {

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -20,6 +20,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   jobHarvestOsloEli = cts.JOB_OP_TYPE_HARVESTING_OSLO_TO_ELI;
   jobEliToNERAndNEL = cts.JOB_OP_TYPE_NER_AND_NEL_ANNOTATIONS;
   jobOparlToELI = cts.JOB_OP_TYPE_HARVESTING_OPARL;
+  jobHarvestPdfToEli = cts.JOB_OP_TYPE_HARVESTING_PDF_TO_ELI;
 
   jobOperations = Array.from(cts.JOB_OP_TYPE_CREATE).map(([key, value]) => {
     return { label: value, uri: key };
@@ -70,6 +71,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked loadingMunicipalities = false;
   @tracked municipalities = [];
   @tracked selectedMunicipality;
+
+  @tracked splitPdf = true;
 
   consumeLokaalBeslistPublishedByOptions = [{ label: 'Ghent' }];
   consumeLokaalBeslistPublishedBy =
@@ -125,6 +128,10 @@ export default class OverviewScheduledJobsNewController extends Controller {
     return cts.isJobWithAuthentication(this.selectedJobOperation?.uri);
   }
 
+  get isHarvestPdfJob() {
+    return this.selectedJobOperation?.uri === this.jobHarvestPdfToEli;
+  }
+
   @action
   updateCredentials(attributeName, credentials) {
     this.credentials[attributeName] = credentials;
@@ -163,6 +170,11 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @action
   changeSelectedMunicipality(org) {
     this.selectedMunicipality = org;
+  }
+
+  @action
+  toggleSplitPdf() {
+    this.splitPdf = !this.splitPdf;
   }
 
   @action
@@ -232,6 +244,11 @@ export default class OverviewScheduledJobsNewController extends Controller {
       if (this.isJobWithCodelist) {
         jobAttributes.codelist = this.codelistUri;
       }
+
+      if (this.isHarvestPdfJob && this.splitPdf) {
+        jobAttributes.splitDecisions = this.splitPdf;
+      }
+
       if (this.isJobWithDecisionSelector) {
         let shapeForTargets;
         if (this.decisionUris) {

--- a/app/models/job.js
+++ b/app/models/job.js
@@ -9,6 +9,7 @@ export default class JobModel extends Model {
   @attr creator;
   @attr operation;
   @attr vendor;
+  @attr('boolean') splitDecisions;
 
   @belongsTo('job-error', { async: true, inverse: null }) error;
   @hasMany('task', { async: true, inverse: 'job', as: 'job' }) tasks;

--- a/app/models/scheduled-job.js
+++ b/app/models/scheduled-job.js
@@ -10,6 +10,7 @@ export default class ScheduledJobModel extends Model {
   @attr creator;
   @attr operation;
   @attr vendor;
+  @attr('boolean') splitDecisions;
 
   @hasMany('scheduled-task', {
     async: true,

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -50,7 +50,12 @@
             />
           </AuFormRow>
         {{/if}}
-
+        {{#if this.isHarvestPdfJob}}
+          <AuToggleSwitch
+            @checked={{this.splitPdf}}
+            @onChange={{this.toggleSplitPdf}}
+          >Split PDF into multiple expressions</AuToggleSwitch>
+        {{/if}}
         {{#if this.isJobWithCodelist}}
           <AuFormRow @alignment="default">
             <AuLabel

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -4,18 +4,18 @@
   @modalOpen={{true}}
   @closeModal={{this.cancelCreateAndStartJob}}
   @overflow={{if this.selectedJobOperation.uri false true}}
-  @size="default">
+  @size="default"
+>
   <:title>Create new job</:title>
   <:body>
     <form class="au-c-form">
-      <AuFormRow
-        class="au-u-margin-bottom"
-        @alignment="default">
+      <AuFormRow class="au-u-margin-bottom" @alignment="default">
         <AuLabel
           for="job-type-select"
           @required={{true}}
           @requiredLabel="Required"
-          @error={{not this.selectedJobOperationValid}}>
+          @error={{not this.selectedJobOperationValid}}
+        >
           Choose operation
         </AuLabel>
         <PowerSelect
@@ -25,108 +25,114 @@
           @options={{this.jobOperations}}
           @selected={{this.selectedJobOperation}}
           @onChange={{this.setJobOperation}}
-          as |option|>
+          as |option|
+        >
           {{option.label}}
         </PowerSelect>
       </AuFormRow>
       {{#if this.selectedJobOperation.uri}}
-          {{#if (this.isJobWithGraphName this.selectedJobOperation.uri)}}
-            <AuFormRow @alignment="default">
-              <AuLabel
-                for="graph-name"
-                @required={{true}}
-                @requiredLabel="Required"
-                @error={{not this.graphNameValid}}>
-                Graph URI
-              </AuLabel>
-              <AuInput
-                id="graph-name"
-                @width="block"
-                value={{this.graphName}}
-                @error={{not this.graphNameValid}}
-                {{on "change" (fn this.setProperty "graphName")}}
-              />
-            </AuFormRow>
-          {{/if}}
-          
-          {{#if this.isJobWithCodelist}}
-            <AuFormRow @alignment="default">
-              <AuLabel
-                for="task-codelist-uri"
-                @required={{true}}
-                @requiredLabel="Required"
-                @error={{not this.codelistUriValid}}
-                >
-                Codelist
-              </AuLabel>
-              <AuInput
-                id="task-codelist-uri"
-                @width="block"
-                value={{this.codelistUri}}
-                @error={{not this.codelistUriValid}}
-                {{on "change" (fn this.setProperty "codelistUri")}}
-              />
-            </AuFormRow>
-            
-            <AuFormRow @alignment="default">
-              <AuLabel for="confidence-threshold">
-                Confidence threshold
-              </AuLabel>
-              <AuInput
-                id="confidence-threshold"
-                @width="block"
-                value={{this.confidenceThreshold}}
-                placeholder="An integer number between 0 and 100"
-                {{on "change" (fn this.setProperty "confidenceThreshold")}}
-              />
-            </AuFormRow>
-          {{/if}}
+        {{#if (this.isJobWithGraphName this.selectedJobOperation.uri)}}
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="graph-name"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.graphNameValid}}
+            >
+              Graph URI
+            </AuLabel>
+            <AuInput
+              id="graph-name"
+              @width="block"
+              value={{this.graphName}}
+              @error={{not this.graphNameValid}}
+              {{on "change" (fn this.setProperty "graphName")}}
+            />
+          </AuFormRow>
+        {{/if}}
 
-          {{#if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
-            <AuFormRow @alignment="default">
-              <AuLabel for="decisions-published-by">
-                Published by
-              </AuLabel>
-              <PowerSelect
-                id="decisions-published-by"
-                @options={{this.consumeLokaalBeslistPublishedByOptions}}
-                @selected={{this.consumeLokaalBeslistPublishedBy}}
-                @onChange={{this.noop}}
-                @disabled={{true}}
-                @renderInPlace={{true}}
-                as |option|>
-                {{option.label}}
-              </PowerSelect>
-              <AuHelpText @warning={{true}}>
-                For now, Lokaal Beslist harvesting is limited to decisions published by Ghent only.
-              </AuHelpText>
-            </AuFormRow>
-            <AuFormRow @alignment="default">
-              <AuLabel
-                for="consumer-sync-mode"
-                @required={{true}}
-                @requiredLabel="Required"
-                @error={{not this.urlValid}}>
-                Sync mode
-              </AuLabel>
-              <AuRadioGroup
-                id="consumer-sync-mode"
-                @name="consumer-sync-mode"
-                @selected={{this.url}}
-                {{on "change" (fn this.setProperty "url")}}
-                as |Group|>
-                <Group.Radio @value={{this.intialConsumerSyncModeUri}}>
-                  Initial sync
-                </Group.Radio>
-                <Group.Radio @value={{this.deltaConsumerSyncModeUri}}>
-                  Delta sync
-                </Group.Radio>
-              </AuRadioGroup>
-            </AuFormRow>
-          {{/if}}
+        {{#if this.isJobWithCodelist}}
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="task-codelist-uri"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.codelistUriValid}}
+            >
+              Codelist
+            </AuLabel>
+            <AuInput
+              id="task-codelist-uri"
+              @width="block"
+              value={{this.codelistUri}}
+              @error={{not this.codelistUriValid}}
+              {{on "change" (fn this.setProperty "codelistUri")}}
+            />
+          </AuFormRow>
 
-          {{#if this.isJobWithDecisionSelector}}
-            <DecisionSelectorConfiguration
+          <AuFormRow @alignment="default">
+            <AuLabel for="confidence-threshold">
+              Confidence threshold
+            </AuLabel>
+            <AuInput
+              id="confidence-threshold"
+              @width="block"
+              value={{this.confidenceThreshold}}
+              placeholder="An integer number between 0 and 100"
+              {{on "change" (fn this.setProperty "confidenceThreshold")}}
+            />
+          </AuFormRow>
+        {{/if}}
+
+        {{#if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
+          <AuFormRow @alignment="default">
+            <AuLabel for="decisions-published-by">
+              Published by
+            </AuLabel>
+            <PowerSelect
+              id="decisions-published-by"
+              @options={{this.consumeLokaalBeslistPublishedByOptions}}
+              @selected={{this.consumeLokaalBeslistPublishedBy}}
+              @onChange={{this.noop}}
+              @disabled={{true}}
+              @renderInPlace={{true}}
+              as |option|
+            >
+              {{option.label}}
+            </PowerSelect>
+            <AuHelpText @warning={{true}}>
+              For now, Lokaal Beslist harvesting is limited to decisions
+              published by Ghent only.
+            </AuHelpText>
+          </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="consumer-sync-mode"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.urlValid}}
+            >
+              Sync mode
+            </AuLabel>
+            <AuRadioGroup
+              id="consumer-sync-mode"
+              @name="consumer-sync-mode"
+              @selected={{this.url}}
+              {{on "change" (fn this.setProperty "url")}}
+              as |Group|
+            >
+              <Group.Radio @value={{this.intialConsumerSyncModeUri}}>
+                Initial sync
+              </Group.Radio>
+              <Group.Radio @value={{this.deltaConsumerSyncModeUri}}>
+                Delta sync
+              </Group.Radio>
+            </AuRadioGroup>
+          </AuFormRow>
+        {{/if}}
+
+        {{#if this.isJobWithDecisionSelector}}
+          <DecisionSelectorConfiguration
             @decisionUris={{this.decisionUris}}
             @decisionUrisValid={{this.decisionUrisValid}}
             @graphForTargetsUri={{this.graphForTargetsUri}}
@@ -135,68 +141,74 @@
             @targetClassUriValid={{this.targetClassUriValid}}
             @propertyPathForTextUri={{this.propertyPathForTextUri}}
             @setProperty={{this.setProperty}}
+          />
+        {{/if}}
+
+        {{#if this.isJobWithMultipleEndpoints}}
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="task-url"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.urlValid}}
+            >
+              URL's
+            </AuLabel>
+            <AuTextarea
+              id="task-url"
+              @width="block"
+              value={{this.url}}
+              @error={{not this.urlValid}}
+              {{on "change" (fn this.setProperty "url")}}
             />
-          {{/if}}
+            <AuHelpText>
+              All url values in this input should be separated by a new-line
+            </AuHelpText>
+          </AuFormRow>
+        {{/if}}
+        {{#if this.isJobWithSingleUrl}}
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="task-url"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.urlValid}}
+            >
+              URL
+            </AuLabel>
+            <AuInput
+              id="task-url"
+              @width="block"
+              value={{this.url}}
+              @error={{not this.urlValid}}
+              {{on "change" (fn this.setProperty "url")}}
+            />
+          </AuFormRow>
+        {{/if}}
 
-          {{#if this.isJobWithMultipleEndpoints}}
-            <AuFormRow @alignment="default">
-              <AuLabel
-                for="task-url"
-                @required={{true}}
-                @requiredLabel="Required"
-                @error={{not this.urlValid}}>
-                URL's
-              </AuLabel>
-              <AuTextarea
-                id="task-url"
-                @width="block"
-                value={{this.url}}
-                @error={{not this.urlValid}}
-                {{on "change" (fn this.setProperty "url")}}
-              />
-              <AuHelpText>
-                All url values in this input should be separated by a new-line
-              </AuHelpText>
-            </AuFormRow>
-          {{/if}}
-          {{#if this.isJobWithSingleUrl}}
-            <AuFormRow @alignment="default">
-              <AuLabel
-                for="task-url"
-                @required={{true}}
-                @requiredLabel="Required"
-                @error={{not this.urlValid}}>
-                URL
-              </AuLabel>
-              <AuInput
-                id="task-url"
-                @width="block"
-                value={{this.url}}
-                @error={{not this.urlValid}}
-                {{on "change" (fn this.setProperty "url")}}
-              />
-            </AuFormRow>
-          {{/if}}
-
-          {{#if this.isJobWithMunicipality}}
-            <AuFormRow @alignment="default">
-              <AuLabel for="decision-passed-by">
-                Municipality
-              </AuLabel>
-              <PowerSelect
-                id="decision-passed-by"
-                @searchEnabled={{true}}
-                @searchField="label"
-                @options={{this.municipalities}}
-                @selected={{this.selectedMunicipality}}
-                @onChange={{this.changeSelectedMunicipality}}
-                @renderInPlace={{true}}
-                @disabled={{or this.loadingMunicipalities (not this.municipalities.length)}}
-                as |option|>
-                {{option.label}}
-              </PowerSelect>
-            </AuFormRow>
-          {{/if}}
+        {{#if this.isJobWithMunicipality}}
+          <AuFormRow @alignment="default">
+            <AuLabel for="decision-passed-by">
+              Municipality
+            </AuLabel>
+            <PowerSelect
+              id="decision-passed-by"
+              @searchEnabled={{true}}
+              @searchField="label"
+              @options={{this.municipalities}}
+              @selected={{this.selectedMunicipality}}
+              @onChange={{this.changeSelectedMunicipality}}
+              @renderInPlace={{true}}
+              @disabled={{or
+                this.loadingMunicipalities
+                (not this.municipalities.length)
+              }}
+              as |option|
+            >
+              {{option.label}}
+            </PowerSelect>
+          </AuFormRow>
+        {{/if}}
 
         <AuFormRow @alignment="default">
           <AuLabel for="task-comment">
@@ -214,7 +226,8 @@
           <AuLabel
             for="task-creator"
             @required={{true}}
-            @requiredLabel="Required">
+            @requiredLabel="Required"
+          >
             Creator
           </AuLabel>
           <AuInput
@@ -225,14 +238,19 @@
             {{on "change" (fn this.setProperty "creator")}}
           />
         </AuFormRow>
-        {{#if (or (eq this.selectedJobOperation.uri this.jobHarvestWorship)
-                  (eq this.selectedJobOperation.uri this.jobHarvestWorshipAndImport))}}
+        {{#if
+          (or
+            (eq this.selectedJobOperation.uri this.jobHarvestWorship)
+            (eq this.selectedJobOperation.uri this.jobHarvestWorshipAndImport)
+          )
+        }}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-vendor"
               @required={{true}}
               @requiredLabel="Required"
-              @error={{not this.vendorValid}}>
+              @error={{not this.vendorValid}}
+            >
               Vendor
             </AuLabel>
             <AuInput
@@ -244,8 +262,7 @@
             />
           </AuFormRow>
         {{/if}}
-        {{#if (and this.authenticationEnabled
-                   this.isJobWithAuthentication)}}
+        {{#if (and this.authenticationEnabled this.isJobWithAuthentication)}}
           <AuthenticationConfiguration
             @options={{this.securitySchemesOptions}}
             @selected={{this.selectedSecurityScheme}}
@@ -262,20 +279,22 @@
   <:footer>
     <AuButtonGroup>
       <AuButton
-        {{on 'click' (perform this.createAndStartJob)}}
+        {{on "click" (perform this.createAndStartJob)}}
         @skin="primary"
         @icon="check"
         @iconAlignment="left"
         @loading={{this.createAndStartJob.isRunning}}
-        @loadingMessage="Creating">
+        @loadingMessage="Creating"
+      >
         Create and start Job
       </AuButton>
       <AuButton
-        {{on 'click' this.cancelCreateAndStartJob}}
+        {{on "click" this.cancelCreateAndStartJob}}
         @skin="secondary"
         @icon="cross"
         @iconAlignment="left"
-        @alert={{true}}>
+        @alert={{true}}
+      >
         Cancel
       </AuButton>
     </AuButtonGroup>

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -4,18 +4,18 @@
   @modalOpen={{true}}
   @closeModal={{this.cancelCreateScheduledJob}}
   @overflow={{if this.selectedJobOperation.uri false true}}
-  @size="default">
+  @size="default"
+>
   <:title>Create new scheduled job</:title>
   <:body>
     <form class="au-c-form">
-      <AuFormRow
-        class="au-u-margin-bottom"
-        @alignment="default">
+      <AuFormRow class="au-u-margin-bottom" @alignment="default">
         <AuLabel
           for="job-type-select"
           @required={{true}}
           @requiredLabel="Required"
-          @error={{not this.selectedJobOperationValid}}>
+          @error={{not this.selectedJobOperationValid}}
+        >
           Choose operation
         </AuLabel>
         <PowerSelect
@@ -25,7 +25,8 @@
           @options={{this.jobOperations}}
           @selected={{this.selectedJobOperation}}
           @onChange={{this.setJobOperation}}
-          as |option|>
+          as |option|
+        >
           {{option.label}}
         </PowerSelect>
       </AuFormRow>
@@ -54,7 +55,7 @@
               @required={{true}}
               @requiredLabel="Required"
               @error={{not this.codelistUriValid}}
-              >
+            >
               Codelist
             </AuLabel>
             <AuInput
@@ -80,63 +81,69 @@
         {{/if}}
 
         {{#if (eq this.selectedJobOperation.uri this.jobHarvestOsloEli)}}
-            <AuFormRow @alignment="default">
-              <AuLabel for="decisions-published-by">
-                Published by
-              </AuLabel>
-              <PowerSelect
-                id="decisions-published-by"
-                @options={{this.consumeLokaalBeslistPublishedByOptions}}
-                @selected={{this.consumeLokaalBeslistPublishedBy}}
-                @onChange={{this.noop}}
-                @disabled={{true}}
-                @renderInPlace={{true}}
-                as |option|>
-                {{option.label}}
-              </PowerSelect>
-              <AuHelpText @warning={{true}}>
-                For now, Lokaal Beslist harvesting is limited to decisions published by Ghent only.
-              </AuHelpText>
-            </AuFormRow>
-            <AuFormRow @alignment="default">
-              <AuLabel
-                for="consumer-sync-mode"
-                @required={{true}}
-                @requiredLabel="Required"
-                @error={{not this.urlValid}}>
-                Sync mode
-              </AuLabel>
-              <AuRadioGroup
-                id="consumer-sync-mode"
-                @name="consumer-sync-mode"
-                @selected={{this.url}}
-                {{on "change" (fn this.setProperty "url")}}
-                as |Group|>
-                <Group.Radio @disabled={{true}}>
-                  Initial sync
-                </Group.Radio>
-                <Group.Radio @value={{this.deltaConsumerSyncModeUri}}>
-                  Delta sync
-                </Group.Radio>
-              </AuRadioGroup>
-              <AuHelpText @warning={{true}}>
-                Initial sync is a one-time run and should be started as a single harvesting job. A scheduled job for delta sync is ideal to keep data up to date.
-              </AuHelpText>
-            </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel for="decisions-published-by">
+              Published by
+            </AuLabel>
+            <PowerSelect
+              id="decisions-published-by"
+              @options={{this.consumeLokaalBeslistPublishedByOptions}}
+              @selected={{this.consumeLokaalBeslistPublishedBy}}
+              @onChange={{this.noop}}
+              @disabled={{true}}
+              @renderInPlace={{true}}
+              as |option|
+            >
+              {{option.label}}
+            </PowerSelect>
+            <AuHelpText @warning={{true}}>
+              For now, Lokaal Beslist harvesting is limited to decisions
+              published by Ghent only.
+            </AuHelpText>
+          </AuFormRow>
+          <AuFormRow @alignment="default">
+            <AuLabel
+              for="consumer-sync-mode"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.urlValid}}
+            >
+              Sync mode
+            </AuLabel>
+            <AuRadioGroup
+              id="consumer-sync-mode"
+              @name="consumer-sync-mode"
+              @selected={{this.url}}
+              {{on "change" (fn this.setProperty "url")}}
+              as |Group|
+            >
+              <Group.Radio @disabled={{true}}>
+                Initial sync
+              </Group.Radio>
+              <Group.Radio @value={{this.deltaConsumerSyncModeUri}}>
+                Delta sync
+              </Group.Radio>
+            </AuRadioGroup>
+            <AuHelpText @warning={{true}}>
+              Initial sync is a one-time run and should be started as a single
+              harvesting job. A scheduled job for delta sync is ideal to keep
+              data up to date.
+            </AuHelpText>
+          </AuFormRow>
         {{/if}}
 
-          {{#if this.isJobWithDecisionSelector}}
-            <DecisionSelectorConfiguration
-              @decisionUris={{this.decisionUris}}
-              @decisionUrisValid={{this.decisionUrisValid}}
-              @graphForTargetsUri={{this.graphForTargetsUri}}
-              @graphForTargetsUriValid={{this.graphForTargetsUriValid}}
-              @targetClassUri={{this.targetClassUri}}
-              @targetClassUriValid={{this.targetClassUriValid}}
-              @propertyPathForTextUri={{this.propertyPathForTextUri}}
-              @setProperty={{this.setProperty}}
-            />
-          {{/if}}
+        {{#if this.isJobWithDecisionSelector}}
+          <DecisionSelectorConfiguration
+            @decisionUris={{this.decisionUris}}
+            @decisionUrisValid={{this.decisionUrisValid}}
+            @graphForTargetsUri={{this.graphForTargetsUri}}
+            @graphForTargetsUriValid={{this.graphForTargetsUriValid}}
+            @targetClassUri={{this.targetClassUri}}
+            @targetClassUriValid={{this.targetClassUriValid}}
+            @propertyPathForTextUri={{this.propertyPathForTextUri}}
+            @setProperty={{this.setProperty}}
+          />
+        {{/if}}
 
         {{#if this.isJobWithMultipleEndpoints}}
           <AuFormRow @alignment="default">
@@ -144,7 +151,8 @@
               for="task-url"
               @required={{true}}
               @requiredLabel="Required"
-              @error={{not this.urlValid}}>
+              @error={{not this.urlValid}}
+            >
               URL's
             </AuLabel>
             <AuTextarea
@@ -166,7 +174,8 @@
               for="task-url"
               @required={{true}}
               @requiredLabel="Required"
-              @error={{not this.urlValid}}>
+              @error={{not this.urlValid}}
+            >
               URL
             </AuLabel>
             <AuInput
@@ -192,8 +201,12 @@
               @selected={{this.selectedMunicipality}}
               @onChange={{this.changeSelectedMunicipality}}
               @renderInPlace={{true}}
-              @disabled={{or this.loadingMunicipalities (not this.municipalities.length)}}
-              as |option|>
+              @disabled={{or
+                this.loadingMunicipalities
+                (not this.municipalities.length)
+              }}
+              as |option|
+            >
               {{option.label}}
             </PowerSelect>
           </AuFormRow>
@@ -204,7 +217,8 @@
             for="cron-pattern"
             @required={{true}}
             @requiredLabel="Required"
-            @error={{not this.cronPatternValid}}>
+            @error={{not this.cronPatternValid}}
+          >
             Cron pattern
           </AuLabel>
           <AuInput
@@ -215,26 +229,33 @@
             {{on "change" (fn this.setProperty "cronPattern")}}
           />
           <AuHelpText @error={{not this.isValidCronPattern}}>
-            The job will be started: {{this.cronDescription}}
+            The job will be started:
+            {{this.cronDescription}}
           </AuHelpText>
           <AuHelpText>
-            <strong>Some examples</strong> <br />
-            Every monday, at 04:05: "5 4 * * 1" <br />
-            At 14:13, only on Monday, only in April: "13 14 * 4 1" <br />
+            <strong>Some examples</strong>
+            <br />
+            Every monday, at 04:05: "5 4 * * 1"
+            <br />
+            At 14:13, only on Monday, only in April: "13 14 * 4 1"
+            <br />
             At 10:38, on day 5 of the month: "38 10 5 * *"
           </AuHelpText>
           <AuHelpText @warning={{true}}>
-            <strong>Warning</strong> <br />
-            With great power there must also come great responsibility. <br>
-            Try to think about spreading the load on the server by spreading
-            the jobs in time.
+            <strong>Warning</strong>
+            <br />
+            With great power there must also come great responsibility.
+            <br />
+            Try to think about spreading the load on the server by spreading the
+            jobs in time.
           </AuHelpText>
         </AuFormRow>
         <AuFormRow @alignment="default">
           <AuLabel
             for="task-creator"
             @required={{true}}
-            @requiredLabel="Required">
+            @requiredLabel="Required"
+          >
             Creator
           </AuLabel>
           <AuInput
@@ -245,14 +266,19 @@
             {{on "change" (fn this.setProperty "creator")}}
           />
         </AuFormRow>
-        {{#if (or (eq this.selectedJobOperation.uri this.jobHarvestWorship)
-                  (eq this.selectedJobOperation.uri this.jobHarvestWorshipAndImport))}}
+        {{#if
+          (or
+            (eq this.selectedJobOperation.uri this.jobHarvestWorship)
+            (eq this.selectedJobOperation.uri this.jobHarvestWorshipAndImport)
+          )
+        }}
           <AuFormRow @alignment="default">
             <AuLabel
               for="task-vendor"
               @required={{true}}
               @requiredLabel="Required"
-              @error={{not this.vendorValid}}>
+              @error={{not this.vendorValid}}
+            >
               Vendor
             </AuLabel>
             <AuInput
@@ -264,8 +290,7 @@
             />
           </AuFormRow>
         {{/if}}
-        {{#if (and this.authenticationEnabled
-                   this.isJobWithAuthentication)}}
+        {{#if (and this.authenticationEnabled this.isJobWithAuthentication)}}
           <AuthenticationConfiguration
             @options={{this.securitySchemesOptions}}
             @selected={{this.selectedSecurityScheme}}
@@ -282,20 +307,22 @@
   <:footer>
     <AuButtonGroup>
       <AuButton
-        {{on 'click' (perform this.createScheduledJob)}}
+        {{on "click" (perform this.createScheduledJob)}}
         @skin="primary"
         @icon="check"
         @iconAlignment="left"
         @loading={{this.createScheduledJob.isRunning}}
-        @loadingMessage="Creating">
+        @loadingMessage="Creating"
+      >
         Create Scheduled Job
       </AuButton>
       <AuButton
-        {{on 'click' this.cancelCreateScheduledJob}}
+        {{on "click" this.cancelCreateScheduledJob}}
         @skin="secondary"
         @icon="cross"
         @iconAlignment="left"
-        @alert={{true}}>
+        @alert={{true}}
+      >
         Cancel
       </AuButton>
     </AuButtonGroup>

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -48,6 +48,12 @@
             {{on "change" (fn this.setProperty "title")}}
           />
         </AuFormRow>
+        {{#if this.isHarvestPdfJob}}
+          <AuToggleSwitch
+            @checked={{this.splitPdf}}
+            @onChange={{this.toggleSplitPdf}}
+          >Split PDF into multiple expressions</AuToggleSwitch>
+        {{/if}}
         {{#if this.isJobWithCodelist}}
           <AuFormRow @alignment="default">
             <AuLabel


### PR DESCRIPTION
Add a toggle to the forms for PDF harvesting jobs to indicated whether a PDF should be split into multiple expressions or not.

## How to test
0. Launch your local app with the backend from [#142](https://github.com/lblod/app-decide/pull/142)
1. Checkout this PR's branch and launch a development instance of the dashboard: `ember serve --proxy=http://localhost:80`
2. Create some jobs and verify whether the created `Job` resource has the correct value for `ext:splitDecisions`.  If the created job is a PDF harvesting job AND the toggle was on (the default), the resource should have as value `true` for `ext:splitDecisions`.  In all other cases it should be `false`, or not set at all. (Same for scheduled jobs)


## Related PRs:
- Backend: [#142](https://github.com/lblod/app-decide/pull/142)
- PDF content extraction service: [#27](https://github.com/semantic-ai/decide-pdf-content-extraction/pull/27)


## Related tickets
- LBRON-1556