### PR TITLE
feat: add target shapes for PDF harvesting jobs

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -192,9 +192,13 @@ export default class OverviewJobsNewController extends Controller {
         this.propertyPathForTextUriValid &&
         this.targetClassUriValid;
     }
-    if (this.isJobWithSingleUrl && isValid) {
+    if (
+      (this.isJobWithSingleUrl || this.isJobWithMultipleEndpoints) &&
+      isValid
+    ) {
       isValid = this.urlValid;
     }
+
     return isValid;
   }
 
@@ -209,7 +213,7 @@ export default class OverviewJobsNewController extends Controller {
       if (!this.validateForm()) return;
 
       let jobName = 'job';
-      if (this.isJobWithDecisionSelector) {
+      if (this.isJobWithDecisionSelector || this.isJobWithMultipleEndpoints) {
         jobName = 'annotation-job';
       }
 
@@ -231,8 +235,17 @@ export default class OverviewJobsNewController extends Controller {
         jobAttributes.splitDecisions = this.splitPdf;
       }
 
+      let shapeForTargets;
+      if (this.isJobWithMultipleEndpoints && this.url) {
+        // NOTE (29/07/2026): These are harvesting jobs and user is required to
+        // provide URLs to harvest from.  Therefore, these jobs do not support
+        // specifying a target graph.
+        shapeForTargets = this.store.createRecord('node-shape', {
+          targetNode: this.url.split(/\n/).filter((x) => x),
+        });
+      }
+
       if (this.isJobWithDecisionSelector) {
-        let shapeForTargets;
         if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetNode: this.decisionUris.split(/\n/).filter((x) => x),
@@ -242,6 +255,9 @@ export default class OverviewJobsNewController extends Controller {
             targetClass: [this.targetClassUri.trim()],
           });
         }
+      }
+
+      if (shapeForTargets) {
         await shapeForTargets.save();
         jobAttributes = Object.assign(jobAttributes, {
           shapeForTargets: [shapeForTargets],

--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -117,10 +117,6 @@ export default class OverviewJobsNewController extends Controller {
     return cts.isJobWithAuthentication(this.selectedJobOperation?.uri);
   }
 
-  get isHarvestPdfJob() {
-    return this.selectedJobOperation?.uri === this.jobHarvestPdfToEli;
-  }
-
   @action
   updateCredentials(attributeName, credentials) {
     this.credentials[attributeName] = credentials;
@@ -231,7 +227,7 @@ export default class OverviewJobsNewController extends Controller {
         jobAttributes.codelist = this.codelistUri;
       }
 
-      if (this.isHarvestPdfJob && this.splitPdf) {
+      if (this.isJobWithMultipleEndpoints && this.splitPdf) {
         jobAttributes.splitDecisions = this.splitPdf;
       }
 

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -205,9 +205,13 @@ export default class OverviewScheduledJobsNewController extends Controller {
         this.propertyPathForTextUriValid &&
         this.targetClassUriValid;
     }
-    if (this.isJobWithSingleUrl && isValid) {
+    if (
+      (this.isJobWithSingleUrl || this.isJobWithMultipleEndpoints) &&
+      isValid
+    ) {
       isValid = this.urlValid;
     }
+
     return isValid;
   }
 
@@ -226,7 +230,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
       await cronSchedule.save();
 
       let jobName = 'scheduled-job';
-      if (this.isJobWithDecisionSelector) {
+      if (this.isJobWithDecisionSelector || this.isJobWithMultipleEndpoints) {
         jobName = 'scheduled-annotation-job';
       }
 
@@ -248,8 +252,17 @@ export default class OverviewScheduledJobsNewController extends Controller {
         jobAttributes.splitDecisions = this.splitPdf;
       }
 
+      let shapeForTargets;
+      if (this.isJobWithMultipleEndpoints && this.url) {
+        // NOTE (29/07/2026): These are harvesting jobs and user is required to
+        // provide URLs to harvest from.  Therefore, these jobs do not support
+        // specifying a target graph.
+        shapeForTargets = this.store.createRecord('node-shape', {
+          targetNode: this.url.split(/\n/).filter((x) => x),
+        });
+      }
+
       if (this.isJobWithDecisionSelector) {
-        let shapeForTargets;
         if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetNode: this.decisionUris.split(/\n/).filter((x) => x),
@@ -259,6 +272,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
             targetClass: [this.targetClassUri.trim()],
           });
         }
+      }
+
+      if (shapeForTargets) {
         await shapeForTargets.save();
         jobAttributes = Object.assign(jobAttributes, {
           shapeForTargets: [shapeForTargets],

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -131,10 +131,6 @@ export default class OverviewScheduledJobsNewController extends Controller {
     return cts.isJobWithAuthentication(this.selectedJobOperation?.uri);
   }
 
-  get isHarvestPdfJob() {
-    return this.selectedJobOperation?.uri === this.jobHarvestPdfToEli;
-  }
-
   @action
   updateCredentials(attributeName, credentials) {
     this.credentials[attributeName] = credentials;
@@ -248,7 +244,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
         jobAttributes.codelist = this.codelistUri;
       }
 
-      if (this.isHarvestPdfJob && this.splitPdf) {
+      if (this.isJobWithMultipleEndpoints && this.splitPdf) {
         jobAttributes.splitDecisions = this.splitPdf;
       }
 

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -50,7 +50,7 @@
             />
           </AuFormRow>
         {{/if}}
-        {{#if this.isHarvestPdfJob}}
+        {{#if this.isJobWithMultipleEndpoints}}
           <AuToggleSwitch
             @checked={{this.splitPdf}}
             @onChange={{this.toggleSplitPdf}}

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -48,7 +48,7 @@
             {{on "change" (fn this.setProperty "title")}}
           />
         </AuFormRow>
-        {{#if this.isHarvestPdfJob}}
+        {{#if this.isJobWithMultipleEndpoints}}
           <AuToggleSwitch
             @checked={{this.splitPdf}}
             @onChange={{this.toggleSplitPdf}}


### PR DESCRIPTION
Extend the flow of creating new jobs such that jobs starting with PDF harvesting also have a linked target shape.  This allows to use the `annotation-job-splitter` to split the tasks in this job into smaller units.


## Approach
For jobs that can have multiple endpoints, currently `JOB_OP_TYPE_HARVESTING_PDF_TO_ELI` and `JOB_OP_TYPE_HARVESTING_PDF_TO_ENRICHED`, we also create a SHACL node shape as target shape linked to the created job.  The URLs provided by the user will be set as values for the node's `sh:targetNode` predicates.

For example, when a user provides two harvesting URLs in the form for a pdf-to-eli or pdf-to-enriched job the resulting shape will look something like:

``` turtle
@prefix sh: <http://www.w3.org/ns/shacl#> .
@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
@prefix ext: <http://mu.semte.ch/vocabularies/ext/> .

# Shape itself
<http://redpencil.data.gift/id/shapes/6A69BB28F17951FDCAD12203> a	sh:NodeShape ;
  mu:uuid "6A69BB28F17951FDCAD12203" ;
  sh:targetNode <http://foo> ,
                <http://bar> .

# Link between job and shape
<http://redpencil.data.gift/id/annotation-job/6A69BB28F17951FDCAD12204>
    ext4:shapeForTargets	<http://redpencil.data.gift/id/shapes/6A69BB28F17951FDCAD12203> .
```


## How to test
0. Checkout the branch for this PR.
1. Launch the local development version of the dashboard: `eds --proxy http://host`
2. Create a jobs involving PDF harvesting and check whether the created job is linked with a correct target shape.
3. Create other kinds of jobs that should have a target shape (see `isJobWithDecisionSelector`) and check whether they are still created with a correct target shape.


## Notes
The first commit removes unneeded duplication introduced in [#67](https://github.com/lblod/frontend-harvesting-self-service/pull/67).  The `isHarvestPdfJob` function duplicated the already existing function `isJobWithMultipleEndpoints`.  This duplication caused these functions to diverge over time.  For example, when [#72](https://github.com/lblod/frontend-harvesting-self-service/pull/72) added the pdf-to-enriched job only to the latter.  This caused the "PDF split" toggle not to be shown in the form for that new job.  Such issues are resolved by removing the `isHarvestPdfJob` in favour of using `isJobWithMultipleEndpoints`.


## Related tickets
- LBRON-1720