### PR TITLE
fix: do not create target shapes for PDF harvesting jobs

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -192,13 +192,9 @@ export default class OverviewJobsNewController extends Controller {
         this.propertyPathForTextUriValid &&
         this.targetClassUriValid;
     }
-    if (
-      (this.isJobWithSingleUrl || this.isJobWithMultipleEndpoints) &&
-      isValid
-    ) {
+    if (this.isJobWithSingleUrl && isValid) {
       isValid = this.urlValid;
     }
-
     return isValid;
   }
 
@@ -213,7 +209,7 @@ export default class OverviewJobsNewController extends Controller {
       if (!this.validateForm()) return;
 
       let jobName = 'job';
-      if (this.isJobWithDecisionSelector || this.isJobWithMultipleEndpoints) {
+      if (this.isJobWithDecisionSelector) {
         jobName = 'annotation-job';
       }
 
@@ -235,17 +231,8 @@ export default class OverviewJobsNewController extends Controller {
         jobAttributes.splitDecisions = this.splitPdf;
       }
 
-      let shapeForTargets;
-      if (this.isJobWithMultipleEndpoints && this.url) {
-        // NOTE (29/07/2026): These are harvesting jobs and user is required to
-        // provide URLs to harvest from.  Therefore, these jobs do not support
-        // specifying a target graph.
-        shapeForTargets = this.store.createRecord('node-shape', {
-          targetNode: this.url.split(/\n/).filter((x) => x),
-        });
-      }
-
       if (this.isJobWithDecisionSelector) {
+        let shapeForTargets;
         if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetNode: this.decisionUris.split(/\n/).filter((x) => x),
@@ -255,9 +242,6 @@ export default class OverviewJobsNewController extends Controller {
             targetClass: [this.targetClassUri.trim()],
           });
         }
-      }
-
-      if (shapeForTargets) {
         await shapeForTargets.save();
         jobAttributes = Object.assign(jobAttributes, {
           shapeForTargets: [shapeForTargets],

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -205,13 +205,9 @@ export default class OverviewScheduledJobsNewController extends Controller {
         this.propertyPathForTextUriValid &&
         this.targetClassUriValid;
     }
-    if (
-      (this.isJobWithSingleUrl || this.isJobWithMultipleEndpoints) &&
-      isValid
-    ) {
+    if (this.isJobWithSingleUrl && isValid) {
       isValid = this.urlValid;
     }
-
     return isValid;
   }
 
@@ -230,7 +226,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
       await cronSchedule.save();
 
       let jobName = 'scheduled-job';
-      if (this.isJobWithDecisionSelector || this.isJobWithMultipleEndpoints) {
+      if (this.isJobWithDecisionSelector) {
         jobName = 'scheduled-annotation-job';
       }
 
@@ -252,17 +248,8 @@ export default class OverviewScheduledJobsNewController extends Controller {
         jobAttributes.splitDecisions = this.splitPdf;
       }
 
-      let shapeForTargets;
-      if (this.isJobWithMultipleEndpoints && this.url) {
-        // NOTE (29/07/2026): These are harvesting jobs and user is required to
-        // provide URLs to harvest from.  Therefore, these jobs do not support
-        // specifying a target graph.
-        shapeForTargets = this.store.createRecord('node-shape', {
-          targetNode: this.url.split(/\n/).filter((x) => x),
-        });
-      }
-
       if (this.isJobWithDecisionSelector) {
+        let shapeForTargets;
         if (this.decisionUris) {
           shapeForTargets = this.store.createRecord('node-shape', {
             targetNode: this.decisionUris.split(/\n/).filter((x) => x),
@@ -272,9 +259,6 @@ export default class OverviewScheduledJobsNewController extends Controller {
             targetClass: [this.targetClassUri.trim()],
           });
         }
-      }
-
-      if (shapeForTargets) {
         await shapeForTargets.save();
         jobAttributes = Object.assign(jobAttributes, {
           shapeForTargets: [shapeForTargets],


### PR DESCRIPTION
Removes the functionality to link SHACL node shapes to jobs involving PDF harvesting that was added in [#73](https://github.com/lblod/frontend-harvesting-self-service/pull/73).  Splitting into multiple tasks per URL to harvest only makes sense for the `pdf-to-eli` job.  In the `pdf-to-enriched` job it conflicts a second split after the `pdf-to-eli` task.

To simplify the frontend (and other services) we opted to remove the splitting of `pdf-scraping` tasks altogether.  Making the previous changes unnecessary, this commit reverts them.


## How to test
See the instructions in the backend PR: [#183](https://github.com/lblod/app-decide/pull/183)


## Related PRs
- Backend: [#183](https://github.com/lblod/app-decide/pull/183)
- pdf-content-extraction: [#36](https://github.com/semantic-ai/decide-pdf-content-extraction/pull/36)


## Related tickets
- LBRON-1720