### PR TITLE
feat: require a municipality when creating a (scheduled) job

### DIFF
--- a/app/controllers/overview/jobs/new.js
+++ b/app/controllers/overview/jobs/new.js
@@ -77,6 +77,7 @@ export default class OverviewJobsNewController extends Controller {
   @tracked loadingMunicipalities = false;
   @tracked municipalities = [];
   @tracked selectedMunicipality;
+  @tracked municipalityValid = true;
 
   @tracked splitPdf = true;
 
@@ -153,6 +154,7 @@ export default class OverviewJobsNewController extends Controller {
   @action
   changeSelectedMunicipality(org) {
     this.selectedMunicipality = org;
+    this.municipalityValid = !!org;
   }
 
   @action
@@ -178,6 +180,7 @@ export default class OverviewJobsNewController extends Controller {
     this.confidenceThresholdValid = !isNaN(
       parseFloat(this.confidenceThreshold),
     );
+    this.municipalityValid = !!this.selectedMunicipality;
 
     let isValid = this.selectedJobOperationValid;
     // Once isValid is false, it stays false until the end
@@ -195,6 +198,11 @@ export default class OverviewJobsNewController extends Controller {
     if (this.isJobWithSingleUrl && isValid) {
       isValid = this.urlValid;
     }
+
+    if (this.isJobWithMunicipality && isValid) {
+      isValid = this.municipalityValid;
+    }
+
     return isValid;
   }
 

--- a/app/controllers/overview/scheduled-jobs/new.js
+++ b/app/controllers/overview/scheduled-jobs/new.js
@@ -74,6 +74,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @tracked loadingMunicipalities = false;
   @tracked municipalities = [];
   @tracked selectedMunicipality;
+  @tracked municipalityValid = true;
 
   @tracked splitPdf = true;
 
@@ -169,6 +170,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
   @action
   changeSelectedMunicipality(org) {
     this.selectedMunicipality = org;
+    this.municipalityValid = !!org;
   }
 
   @action
@@ -190,6 +192,7 @@ export default class OverviewScheduledJobsNewController extends Controller {
     this.confidenceThresholdValid = !isNaN(
       parseFloat(this.confidenceThreshold),
     );
+    this.municipalityValid = !!this.selectedMunicipality;
 
     // Once isValid is false, it stays false until the end
     let isValid =
@@ -208,6 +211,11 @@ export default class OverviewScheduledJobsNewController extends Controller {
     if (this.isJobWithSingleUrl && isValid) {
       isValid = this.urlValid;
     }
+
+    if (this.isJobWithMunicipality && isValid) {
+      isValid = this.municipalityValid;
+    }
+
     return isValid;
   }
 

--- a/app/routes/overview/jobs/new.js
+++ b/app/routes/overview/jobs/new.js
@@ -17,5 +17,6 @@ export default class OverviewJobsNewRoute extends Route {
     controller.set('selectedSecurityScheme', null);
     controller.set('credentials', {});
     controller.set('securityScheme', {});
+    controller.set('municipalityValid', true);
   }
 }

--- a/app/routes/overview/scheduled-jobs/new.js
+++ b/app/routes/overview/scheduled-jobs/new.js
@@ -18,5 +18,6 @@ export default class OverviewScheduledJobsNewRoute extends Route {
     controller.set('selectedSecurityScheme', null);
     controller.set('securityScheme', {});
     controller.set('credentials', {});
+    controller.set('municipalityValid', true);
   }
 }

--- a/app/templates/overview/jobs/new.hbs
+++ b/app/templates/overview/jobs/new.hbs
@@ -193,12 +193,16 @@
 
         {{#if this.isJobWithMunicipality}}
           <AuFormRow @alignment="default">
-            <AuLabel for="decision-passed-by">
+            <AuLabel
+              for="decision-passed-by"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.municipalityValid}}
+            >
               Municipality
             </AuLabel>
             <PowerSelect
               id="decision-passed-by"
-              @searchEnabled={{true}}
               @searchField="label"
               @options={{this.municipalities}}
               @selected={{this.selectedMunicipality}}

--- a/app/templates/overview/scheduled-jobs/new.hbs
+++ b/app/templates/overview/scheduled-jobs/new.hbs
@@ -196,7 +196,12 @@
 
         {{#if this.isJobWithMunicipality}}
           <AuFormRow @alignment="default">
-            <AuLabel for="decision-passed-by">
+            <AuLabel
+              for="decision-passed-by"
+              @required={{true}}
+              @requiredLabel="Required"
+              @error={{not this.municipalityValid}}
+            >
               Municipality
             </AuLabel>
             <PowerSelect


### PR DESCRIPTION
In the context of DECIDe providing a municipality is mandatory when creating some types of (scheduled) job.  This PR makes that field mandatory for the relevant job types.


## How to test
0. Checkout the branch for this PR
1. Launch a local version of this dashboard: `eds --proxy http://host`
2. Go to `http://localhost:4200`
3. Create a new job of a type that allows to provide a municipality and experiment with providing a municipality and leaving the field empty.

Note, the following jobs require a municipality:
- Harvest PDFs from Website URL & Publish as ELI
- Harvest PDFs from Website URL, Publish as ELI and Enrich
- Harvest JSON from Website URL, Publish as ELI
- Harvest JSON from Website URL, Publish as ELI and Enrich
- Perform Named Entity Recognition & Entity Linking on ELI decisions & Publish
- Perform Named Entity Linking on ELI decisions & Publish